### PR TITLE
fix(audio): diagnose missing ALSA card

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ typing single letters. Numbered table, color-coded state, cached.
 
   #   Module                  Version  Installed State          Description
   ----------------------------------------------------------------------------------
-  1   audio-fix               2.1.0    2.1.0     up to date     Speakers + mics + clean panel
+  1   audio-fix               2.1.1    2.1.1     up to date     Speakers + mics + clean panel
   2   display-fix             1.1.2    1.1.2     up to date     xe Panel Replay / PSR lockup
   3   intel-perf-fix          1.1.0    1.1.0     up to date     thermald + intel-lpmd
   4   keyboard-backlight-fix  1.1.0    1.1.0     up to date     (optional) KDE backlight slider
@@ -195,6 +195,12 @@ as of `alsa-ucm-conf 1.2.16`**, so on 1.2.16+ this module installs only the
 firmware + the SSP2-BT drop-in; the UCM rows below are dropped in **only as a
 fallback on `alsa-ucm-conf < 1.2.16`** (and the `NoExtract` pin is removed
 automatically once the package crosses 1.2.16).
+
+> **If PipeWire shows only “Dummy Output”:** the kernel did not register an
+> ALSA card, so firmware/UCM installation cannot help yet. Check
+> `./patch.sh status audio-fix`; the known `SDW3-Playback-SimpleJack` /
+> `sof_sdw ... error -12` failure requires kernel patch
+> [`0004`](upstream-patches/0004-soundwire-dmi-quirks-Disable-ghost-rt722-on-ASUS-Exp.patch).
 
 | File | Path | What it does |
 |---|---|---|

--- a/audio-fix/README.md
+++ b/audio-fix/README.md
@@ -95,6 +95,28 @@ pactl set-default-sink alsa_output.pci-0000_00_1f.3-platform-sof_sdw.HiFi__Speak
 `./patch.sh status audio-fix` also reports the cs35l56 firmware state and the
 active card profile.
 
+### "Dummy Output" / no ALSA card
+
+The userspace files in `audio-fix` can route and tune a card only after the
+kernel has registered it. If `wpctl status` shows only **Dummy Output**, check:
+
+```sh
+cat /proc/asound/cards
+journalctl -k -b | grep -Ei 'sof|soundwire|cs35|cs42|snd'
+```
+
+An empty card list together with `SDW3-Playback-SimpleJack`, `-EEXIST`, or
+`sof_sdw ... error -12` in the kernel log is the known phantom-RT722 failure.
+The duplicate SoundWire link aborts the `sof_sdw` probe before firmware, UCM,
+PipeWire, or WirePlumber can participate. Restarting WirePlumber and
+reinstalling this module cannot create the missing card.
+
+The kernel-side fix is
+[`upstream-patches/0004-soundwire-dmi-quirks-Disable-ghost-rt722-on-ASUS-Exp.patch`](../upstream-patches/0004-soundwire-dmi-quirks-Disable-ghost-rt722-on-ASUS-Exp.patch).
+It must be applied to the kernel you boot; merely having the patch file in this
+repository does not modify a distribution kernel. `./patch.sh status
+audio-fix` now detects this failure signature and points to that patch.
+
 ## Uninstall
 
 ```sh

--- a/audio-fix/module.sh
+++ b/audio-fix/module.sh
@@ -41,7 +41,7 @@
 
 MODULE_NAME="audio-fix"
 MODULE_DESC="ASUS ExpertBook Ultra (B9406CAA) speaker/headphone audio via HiFi UCM + cs35l56 firmware"
-MODULE_VERSION="2.1.0"
+MODULE_VERSION="2.1.1"
 
 # Always-installed payload: OEM firmware (fallback for linux-firmware-cirrus
 # < 20260519) + the SSP2-BT topology-noise silencer. The HiFi UCM files are
@@ -133,7 +133,7 @@ module_post_uninstall() {
 }
 
 module_status_extra() {
-  local fw_state="" prof="" kmsg
+  local fw_state="" prof="" kmsg cards
   kmsg="$(journalctl -k -b 0 --no-pager 2>/dev/null || true)"
   if [[ $kmsg == *"Calibration applied"* ]]; then
     fw_state="${c_ok}cs35l56 firmware patched, calibration applied${c_off}"
@@ -144,12 +144,33 @@ module_status_extra() {
   fi
   printf '  cs35l56:  %s\n' "$fw_state"
 
+  # PipeWire's "Dummy Output" is not a UCM/profile problem: it means the
+  # kernel never registered an ALSA card. Previously status printed no card
+  # line at all in that case, which made a successful file install look like a
+  # successful audio fix. Detect it before asking users to restart WirePlumber.
+  cards="$(cat /proc/asound/cards 2>/dev/null || true)"
+  if [[ -z $cards || $cards == *"no soundcards"* ]]; then
+    printf '  card:     %sno ALSA sound card registered (PipeWire will show Dummy Output)%s\n' \
+      "$c_warn" "$c_off"
+    if grep -Eq 'SDW3-Playback-SimpleJack|sof_sdw.*(error -12|failed with error -12)' <<<"$kmsg"; then
+      printf '  kernel:   %sghost rt722 duplicate-link failure detected; audio-fix cannot repair this in userspace%s\n' \
+        "$c_warn" "$c_off"
+      printf '            apply upstream-patches/0004-soundwire-dmi-quirks-Disable-ghost-rt722-on-ASUS-Exp.patch to the running kernel\n'
+    else
+      printf '  kernel:   %sinspect: journalctl -k -b | grep -Ei "sof|soundwire|cs35|cs42|snd"%s\n' \
+        "$c_dim" "$c_off"
+    fi
+    return
+  fi
+
   if command -v pactl >/dev/null 2>&1; then
     prof="$(pactl list cards 2>/dev/null | awk -F'Active Profile: ' '/Active Profile/ {print $2; exit}')"
     if [[ $prof == HiFi* ]]; then
       printf '  card:     %sActive Profile = HiFi (proper Speaker/Headphone routing)%s\n' "$c_ok" "$c_off"
     elif [[ -n $prof ]]; then
       printf '  card:     %sActive Profile = %s (expected HiFi -- restart WirePlumber)%s\n' "$c_warn" "$prof" "$c_off"
+    else
+      printf '  card:     %sALSA card exists, but PipeWire exposes no active card profile%s\n' "$c_warn" "$c_off"
     fi
   fi
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -596,7 +596,7 @@ sudo reboot</code></pre>
 
   #   Module                  Version  Installed State          Description
   ----------------------------------------------------------------------------------
-  1   audio-fix               2.1.0    2.1.0     up to date     Speakers + mics + clean panel
+  1   audio-fix               2.1.1    2.1.1     up to date     Speakers + mics + clean panel
   2   display-fix             1.1.2    1.1.2     up to date     xe Panel Replay / PSR lockup
   3   intel-perf-fix          1.1.0    1.1.0     up to date     thermald + intel-lpmd
   4   keyboard-backlight-fix  1.1.0    1.1.0     up to date     (optional) KDE backlight slider
@@ -643,7 +643,7 @@ Actions
           </tr>
           <tr>
             <td><a href="https://github.com/burakgon/asus-expertbook-linux/tree/main/audio-fix"><code>audio-fix</code></a></td>
-            <td><span class="mono">2.1.0</span></td>
+            <td><span class="mono">2.1.1</span></td>
             <td>Cirrus CS35L56 firmware + HiFi UCM (upstream in alsa-ucm-conf 1.2.16) + SSP2-BT noise fix</td>
           </tr>
           <tr>
@@ -711,7 +711,15 @@ cs35l56 sdw:0:2:01fa:3556:01:1: FIRMWARE_MISSING                    ← without
 ─────────────────────────────────────────────────────────────────────────
 cs35l56 sdw:0:2:01fa:3556:01:0: Calibration applied                 ← with
 cs35l56 sdw:0:2:01fa:3556:01:0: Tuning PID: 0x23134, SID: 0x470200  ← with</code></pre>
-        <p><strong>Files installed (v2.1.0):</strong></p>
+        <p>
+          <strong>Only “Dummy Output”?</strong> That means the kernel did not
+          register an ALSA card, so these userspace files cannot help yet. Run
+          <code>./patch.sh status audio-fix</code>. The known
+          <code>SDW3-Playback-SimpleJack</code> / <code>sof_sdw ... error -12</code>
+          signature requires the kernel-side ghost-RT722
+          <a href="https://github.com/burakgon/asus-expertbook-linux/blob/main/upstream-patches/0004-soundwire-dmi-quirks-Disable-ghost-rt722-on-ASUS-Exp.patch">0004 patch</a>.
+        </p>
+        <p><strong>Files installed (v2.1.1):</strong></p>
         <ul>
           <li><code>/lib/firmware/cirrus/cs35l56-b0-dsp1-misc-104315e4-l2u{0,1}.bin</code> — per-OEM tuning blobs (fallback for <code>linux-firmware-cirrus &lt; 20260519</code>)</li>
           <li><code>/lib/firmware/cirrus/cs35l56-b0-dsp1-misc-104315e4-l2u{0,1}.wmfw</code> — generic CS35L56 Rev 3.13.4 firmware patch (chip ROM upgrades 3.4.4 → 3.13.4)</li>


### PR DESCRIPTION
## Summary

- report a missing ALSA card instead of silently omitting card status
- recognize the known ghost-RT722 duplicate SoundWire link failure
- point affected users to kernel patch 0004 instead of a WirePlumber restart
- document why firmware and UCM cannot repair PipeWire Dummy Output
- bump audio-fix to 2.1.1 and keep the Pages documentation in sync

Related to #2.

## Validation

- `bash -n patch.sh audio-fix/module.sh`
- simulated an empty ALSA card list with `SDW3-Playback-SimpleJack` and `sof_sdw ... error -12`
- asserted that status prints the missing-card, ghost-RT722, and patch-0004 guidance
- `git diff --check`