### PR TITLE
feat(ish): ish-firmware module — ASUS-signed Sensor Hub image so the ambient light sensor exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ curl -fsSL https://raw.githubusercontent.com/burakgon/asus-expertbook-linux/main
 | Audio codec | Cirrus `CS42L43` + 2× `CS35L56` (subsystem `1043:15e4`) | Per-OEM speaker firmware needed |
 | Wi-Fi card | Intel Wi-Fi 7 `BE211` (`8086:e440`) | iwlmld-mode tunables apply here |
 | Ambient light sensor | `iio` device named `als` with `in_illuminance_raw` | `keyboard-backlight-auto` reads it to drive the keyboard backlight |
+| Intel Sensor Hub | PCI `8086:e445` with `/sys/bus/ishtp/devices` populated | The `als` device only exists once the ISH runs ASUS's signed image; `ish-firmware` installs it |
 | Distro | Arch / CachyOS / any Arch-derivative | The patcher uses `pacman` and reads `/etc` paths Arch-style |
 
 If you're on a sibling model (`104315d4` / `104315f4`) and willing to test, see
@@ -57,6 +58,7 @@ different distro, the modules themselves still apply — only the
 | **Intel Core Ultra X7/X9** Panther Lake hybrid (P + E + LP-E cores) | **Idle power 4–5 W**, fans audible at idle, P-cores never deep-sleep. | Idle ≈ 2–2.5 W. Workload parks on a single LP-E core. P-cores reach `C10`. | [`intel-perf-fix`](intel-perf-fix/) |
 | **USB UVC webcam** (+ idle Panther Lake NPU) | **No AI camera effects.** Windows Studio Effects (background blur, smart framing) doesn't exist on Linux out of the box. | **CPU** background blur via OBS + `obs-backgroundremoval`, exposed as a virtual camera ("AI Camera"). *(NPU offload is not available in the OBS plugin on Linux — see the module's reality-check note.)* | [`webcam-ai-fix`](webcam-ai-fix/) |
 | **Shinetech USB camera + UEFI ESRT target** | ASUS camera firmware 3009 is distributed as a Windows EXE. | Compares locally against the fixed, verified 3009 baseline; offers a confirmed `fwupd` capsule update without running Windows or querying ASUS for newer versions. | [`camera-firmware`](camera-firmware/) |
+| **Intel Sensor Hub** (`8086:e445`, carries the ambient light sensor) | **No ambient light sensor at all.** The kernel's generic `ish_ptl.bin` is rejected (`ISH loader: cmd 2 failed 10`); linux-firmware has no ASUS image, so `/sys/bus/iio` never gets an `als` device. | The ASUS-signed image from ASUS's own Sensor Hub driver package is verified and installed under the per-OEM name the kernel requests; `iio:device1 = als` appears and `keyboard-backlight-auto` has a sensor to read. | [`ish-firmware`](ish-firmware/) |
 | **Ambient light sensor** (`iio` `als`) + keyboard backlight | **The backlight never adapts to the room.** KDE PowerDevil reads the sensor for *screen* brightness only; the keyboard stays wherever the Fn keys left it, and comes up dark after every boot. | *(optional)* The backlight follows the room using Windows 11's documented ALR curve — dim in the dark, brightest around 40–100 lux, off above 200–300 lux. Forced off with the lid shut; Fn keys still take over. | [`keyboard-backlight-auto`](keyboard-backlight-auto/) |
 | **ASUS BIOS `SLKB` ACPI method** (BIOS `B9406CAA.312`) | **Keyboard brightness reads back as `0`** no matter what it was set to — sysfs, UPower and `brightnessctl` all report a dark keyboard, and `systemd-backlight` restores `0` at every boot. Writes themselves reach the EC fine. | *(superseded)* Nothing to fix on the write path: the v1.x `asusd` workaround targeted an ACPI branch mainline `asus-wmi` never reaches. Kept for older firmware, skips install by default. | [`keyboard-backlight-fix`](keyboard-backlight-fix/) |
 
@@ -82,7 +84,7 @@ After reboot:
 ./patch.sh status
 ```
 
-You should see all nine modules `up to date` (or not applicable) and their runtime
+You should see all ten modules `up to date` (or not applicable) and their runtime
 checks green — except `keyboard-backlight-fix`, which reports `not installed`
 because it deliberately supersedes itself.
 
@@ -570,6 +572,27 @@ AC connected applies it; current/equal/newer firmware is never reflashed.
 
 See [`camera-firmware/README.md`](camera-firmware/README.md) for the hashes,
 ESRT GUID and local-package paths.
+
+### 10. [`ish-firmware`](ish-firmware/) — the ambient light sensor's missing firmware
+
+The ambient light sensor sits behind the Intel Integrated Sensor Hub
+(`00:12.0`, `8086:e445`), which only runs after the kernel uploads an
+OEM-signed image at boot. Before the generic `ish_ptl.bin` the loader asks for
+`intel/ish/ish_ptl_<crc32(sys_vendor)>_<crc32(product_family)>.bin` — a rule
+that reproduces linux-firmware's Lenovo/Dell entries exactly — but linux-firmware
+ships no ASUS image, and this board rejects the generic one
+(`ISH loader: cmd 2 failed 10`). Result: no `als` device, ever.
+
+Same approach as `camera-firmware`: the module downloads (or uses a verified
+local copy of) ASUS's fixed **Intel Sensor Hub V5.8.62.0** package, checks the
+pinned SHA-256 of the EXE and of the embedded
+`AsusSign_ishS_SI_B9406CAA_5.8.1.7783.bin`, installs it as
+`ish_ptl_59b8d9f2_84881981.bin` and reloads `intel_ish_ipc`. Nothing is
+flashed and nothing ASUS-owned is redistributed. Install it before
+`keyboard-backlight-auto`.
+
+See [`ish-firmware/README.md`](ish-firmware/README.md) for the evidence,
+hashes and the naming rule.
 
 ## How it works
 

--- a/ish-firmware/README.md
+++ b/ish-firmware/README.md
@@ -1,0 +1,129 @@
+# ish-firmware
+
+Install the ASUS-signed Intel Sensor Hub (ISH) firmware image under the file
+name the kernel looks for, so the ambient light sensor exists on Linux.
+
+Without it the B9406CAA has **no `als` device at all**, and
+[`keyboard-backlight-auto`](../keyboard-backlight-auto/) has nothing to read.
+The only `iio` device is the webcam's proximity sensor.
+
+## Symptom
+
+```
+$ cat /sys/bus/iio/devices/iio:device*/name
+prox
+$ journalctl -k -b | grep 'ISH loader'
+intel_ish_ipc 0000:00:12.0: ISH loader: load firmware: intel/ish/ish_ptl.bin
+intel_ish_ipc 0000:00:12.0: ISH loader: cmd 2 failed 10
+intel_ish_ipc 0000:00:12.0: ISH loader: cmd 2 failed 10
+intel_ish_ipc 0000:00:12.0: ISH loader: cmd 2 failed 10
+```
+
+`/sys/bus/ishtp/devices/` stays empty: the sensor hub never comes up, so no
+HID sensor collection is enumerated and the `hid_sensor_als` driver has
+nothing to bind to.
+
+## Cause
+
+The ambient light sensor is wired to the Intel Integrated Sensor Hub
+(PCI `00:12.0`, `8086:e445`). The ISH runs a firmware image that the kernel
+uploads into its RAM at every boot (`intel_ish_ipc` → "ISH loader"). The image
+must be signed for the OEM board; a generic one is rejected.
+
+Before falling back to the generic `intel/ish/ish_ptl.bin`, the loader
+requests a per-OEM file:
+
+```
+intel/ish/ish_<platform>_<crc32(sys_vendor)>_<crc32(product_family)>.bin
+```
+
+The rule is not documented in `WHENCE`, but it reproduces linux-firmware's own
+entries exactly:
+
+| DMI string | CRC-32 | linux-firmware file |
+|---|---|---|
+| `LENOVO` | `53c4ffad` | `ish_ptl_53c4ffad_75d6ebe2.bin` |
+| `ThinkPad X1 Carbon Gen 14` (product_family) | `75d6ebe2` | ↑ |
+| `Dell Inc.` | `39ceeaf8` | `ish_ptl_39ceeaf8.bin` |
+| `ASUS` | `59b8d9f2` | **none shipped** |
+| `ASUS EXPERTBOOK` (product_family) | `84881981` | **none shipped** |
+
+linux-firmware 20260810 carries ISH Panther Lake images from Lenovo, Dell and
+HP only, each submitted by that vendor under its own licence file. There is no
+ASUS image, so on this board the kernel ends up with the generic file, which
+the ISH's security engine refuses.
+
+The image ASUS uses on Windows ships inside its **Intel Sensor Hub V5.8.62.0**
+driver package as
+`IshHeciExtensionTemplate/x64/FWImage/0004/AsusSign_ishS_SI_B9406CAA_5.8.1.7783.bin`
+(420352 bytes). It is the same `$CPD`/`ISHM` container format as
+`ish_ptl.bin`, one build newer than the generic 5.8.1.7778, and the same build
+as Dell's `ish_ptl_39ceeaf8_581.7783.0.bin`.
+
+## What the module does
+
+Same pattern as [`camera-firmware`](../camera-firmware/): the ASUS-owned file
+is **not** redistributed here and the Windows program is never run.
+
+1. Refuses to run unless `board_name` is `B9406CAA` (the image is signed for
+   this board).
+2. Uses a verified local copy of `SensorHub_CC_Intel_Z_V5.8.62.0_48695.exe`
+   if one is found next to the repo, in `~/Desktop` or `~/Downloads`
+   (`ASUS_ISH_FW_EXE=/path` overrides), otherwise downloads that one fixed
+   ASUS artifact (5 MB) — no "latest version" query.
+3. Checks the outer SHA-256, carves the embedded 7z resource at its fixed
+   offset, extracts, checks the image SHA-256.
+4. Installs it as `/lib/firmware/intel/ish/ish_ptl_59b8d9f2_84881981.bin`
+   (name computed from the live DMI strings; falls back to the constant when
+   `python3` is absent).
+5. Reloads `intel_ish_ipc` so the new image is uploaded without a reboot, and
+   reports the `als` device.
+
+Nothing is flashed. The image lives in ISH RAM for the duration of the boot;
+`./patch.sh uninstall ish-firmware` deletes the file and the machine is back
+to the generic-image behaviour after the next reboot.
+
+## Install
+
+```sh
+./patch.sh install ish-firmware
+./patch.sh status ish-firmware
+```
+
+Expected status on this laptop:
+
+```
+  expected: /lib/firmware/intel/ish/ish_ptl_59b8d9f2_84881981.bin
+  image:    verified ASUS-signed 5.8.1.7783
+  loader:   intel/ish/ish_ptl_59b8d9f2_84881981.bin → FW 5.8.1.7783
+  ishtp:    5 client devices enumerated
+  als:      iio:device1 reading 24.8 lux
+```
+
+And in the kernel log:
+
+```
+intel_ish_ipc 0000:00:12.0: ISH loader: load firmware: intel/ish/ish_ptl_59b8d9f2_84881981.bin
+intel_ish_ipc 0000:00:12.0: ISH loader: firmware loaded. size:420352
+intel_ish_ipc 0000:00:12.0: ISH loader: FW base version: 5.8.1.7783
+ish-hid {33AECD58-...}: [hid-ish]: enum_devices_done OK, num_hid_devices=1
+hid-sensor-hub 001F:8087:0AC2.0009: hidraw8: SENSOR HUB HID v2.00 Device [hid-ishtp 8087:0AC2]
+```
+
+Install this **before** `keyboard-backlight-auto`; the daemon needs the `als`
+device that only exists once the ISH is running.
+
+## Verified on
+
+- ASUS EXPERTBOOK B9406CAA, BIOS 312, CachyOS, Linux 7.2.3-1-cachyos,
+  linux-firmware 20260810 — 2026-09-07.
+
+## Scope and upstream
+
+- Other ExpertBook models need their own ASUS-signed image (a different file
+  in their own Sensor Hub package); the module refuses to install on them
+  rather than guess.
+- The durable fix is for ASUS to submit the image to linux-firmware the way
+  Lenovo, Dell and HP did (`LICENCE.lenovo`, `LICENSE.dell`, `LICENCE.HP`);
+  only the vendor can grant that redistribution licence, which is also why
+  this repository does not bundle the file.

--- a/ish-firmware/module.sh
+++ b/ish-firmware/module.sh
@@ -1,0 +1,326 @@
+# shellcheck shell=bash
+# ish-firmware module for the ASUS ExpertBook Ultra B9406CAA.
+# Sourced by ../patch.sh.
+#
+# The ambient light sensor on this laptop is not a standalone I2C device. It
+# sits behind the Intel Integrated Sensor Hub (ISH, PCI 00:12.0, 8086:e445),
+# and the ISH only runs after the kernel uploads a firmware image into it at
+# every boot. That image must be signed for the OEM board: the generic
+# intel/ish/ish_ptl.bin from linux-firmware is rejected by this machine with
+#
+#   intel_ish_ipc 0000:00:12.0: ISH loader: load firmware: intel/ish/ish_ptl.bin
+#   intel_ish_ipc 0000:00:12.0: ISH loader: cmd 2 failed 10
+#
+# and no ISH client device is ever enumerated, so /sys/bus/iio has no `als`
+# device and keyboard-backlight-auto has nothing to read.
+#
+# Before falling back to the generic file the kernel looks for a per-OEM
+# image named
+#
+#   intel/ish/ish_<platform>_<crc32(sys_vendor)>_<crc32(product_family)>.bin
+#
+# (verified against linux-firmware's own entries: crc32("LENOVO") =
+# 53c4ffad and crc32("ThinkPad X1 Carbon Gen 14") = 75d6ebe2 reproduce
+# ish_ptl_53c4ffad_75d6ebe2.bin exactly). linux-firmware ships such images
+# for Lenovo, Dell and HP only; there is no ASUS entry. On this board the
+# expected name is ish_ptl_59b8d9f2_84881981.bin.
+#
+# ASUS distributes the matching, ASUS-signed image inside its Windows
+# "Intel Sensor Hub" driver package as
+# IshHeciExtensionTemplate/x64/FWImage/0004/AsusSign_ishS_SI_B9406CAA_5.8.1.7783.bin.
+# Like camera-firmware, this module never redistributes that file and never
+# runs the Windows program: it downloads the fixed ASUS artifact (or uses a
+# verified local copy), checks the outer SHA-256, carves the embedded 7z
+# resource, checks the image SHA-256 and installs it under the name the kernel
+# expects. The image is uploaded to ISH RAM at each boot; nothing is flashed.
+
+MODULE_NAME="ish-firmware"
+MODULE_DESC="B9406CAA ambient light sensor: install ASUS's signed Intel Sensor Hub image the kernel looks for"
+MODULE_VERSION="5.8.1.7783"
+MODULE_FILES=()
+
+ISH_MODEL="B9406CAA"
+ISH_FW_DIR="/lib/firmware/intel/ish"
+ISH_FW_PLATFORM="ptl"
+# crc32("ASUS") = 59b8d9f2, crc32("ASUS EXPERTBOOK") = 84881981. Used when
+# python3 is unavailable to compute the name from the live DMI strings.
+ISH_FW_FALLBACK_NAME="ish_ptl_59b8d9f2_84881981.bin"
+ISH_FW_SHA256="3f5c273dd625eaff9ef2fba95600563e14c1d7d357fa10b7de8c2dc5de3b7e51"
+ISH_FW_IMAGE_NAME="AsusSign_ishS_SI_B9406CAA_5.8.1.7783.bin"
+
+ISH_PACKAGE_NAME="SensorHub_CC_Intel_Z_V5.8.62.0_48695.exe"
+ISH_PACKAGE_URL="https://dlcdnets.asus.com/pub/ASUS/Commercial_NB/Image/Driver/Chipset/48695/SensorHub_CC_Intel_Z_V5.8.62.0_48695.exe"
+ISH_PACKAGE_SHA256="ae21b72de686cb29c9f184cfe60680ff52728bacfaeb1e2ead3fbffd792224b3"
+# The verified ASUS self-extractor carries a 7z resource at this byte range.
+# Fixed offsets are safe because the complete outer file is hash-pinned first.
+ISH_PAYLOAD_OFFSET=4283536
+ISH_PAYLOAD_SIZE=1059104
+
+ish_is_supported_model() {
+  local board
+  board="$(tr -d '\n' </sys/class/dmi/id/board_name 2>/dev/null || true)"
+  [[ $board == "$ISH_MODEL" ]]
+}
+
+# Name the kernel's ISH loader requests before the generic fallback.
+ish_fw_name() {
+  local vendor family
+  vendor="$(tr -d '\n' </sys/class/dmi/id/sys_vendor 2>/dev/null || true)"
+  family="$(tr -d '\n' </sys/class/dmi/id/product_family 2>/dev/null || true)"
+  if command -v python3 >/dev/null 2>&1 && [[ -n $vendor && -n $family ]]; then
+    python3 - "$ISH_FW_PLATFORM" "$vendor" "$family" <<'PY'
+import sys, zlib
+plat, vendor, family = sys.argv[1:4]
+print("ish_%s_%08x_%08x.bin" % (plat, zlib.crc32(vendor.encode()), zlib.crc32(family.encode())))
+PY
+  else
+    printf '%s\n' "$ISH_FW_FALLBACK_NAME"
+  fi
+}
+
+ish_fw_path() {
+  printf '%s/%s\n' "$ISH_FW_DIR" "$(ish_fw_name)"
+}
+
+ish_file_verified() {
+  local path="$1" hash
+  [[ -f $path ]] || return 1
+  hash="$(sha256sum "$path" | awk '{print $1}')"
+  [[ $hash == "$ISH_FW_SHA256" ]]
+}
+
+# The ishtp bus only gets client devices after the firmware is up.
+ish_running() {
+  local d
+  for d in /sys/bus/ishtp/devices/*; do
+    [[ -e $d ]] && return 0
+  done
+  return 1
+}
+
+ish_als_dev() {
+  local d
+  for d in /sys/bus/iio/devices/iio:device*; do
+    [[ -r "$d/name" ]] || continue
+    if [[ "$(cat "$d/name" 2>/dev/null)" == "als" && -r "$d/in_illuminance_raw" ]]; then
+      printf '%s\n' "$d"
+      return 0
+    fi
+  done
+  return 1
+}
+
+ish_require_tools() {
+  local packages=()
+  command -v 7z >/dev/null 2>&1 || packages+=(7zip)
+  command -v curl >/dev/null 2>&1 || packages+=(curl)
+  if (( ${#packages[@]} > 0 )); then
+    if command -v pacman >/dev/null 2>&1; then
+      log "[ish-firmware] installing required tools: ${packages[*]}"
+      pacman -S --needed --noconfirm "${packages[@]}"
+    else
+      die "[ish-firmware] missing tools: ${packages[*]}"
+    fi
+  fi
+}
+
+ish_find_local_package() {
+  local owner_uid owner_home candidate
+  local candidates=(
+    "$MODULE_DIR/$ISH_PACKAGE_NAME"
+    "$ROOT_DIR/$ISH_PACKAGE_NAME"
+  )
+
+  owner_uid="$(stat -c '%u' "$ROOT_DIR" 2>/dev/null || true)"
+  owner_home="$(getent passwd "$owner_uid" 2>/dev/null | cut -d: -f6)"
+  if [[ -n $owner_home ]]; then
+    candidates+=(
+      "$owner_home/Desktop/$ISH_PACKAGE_NAME"
+      "$owner_home/Downloads/$ISH_PACKAGE_NAME"
+      "$owner_home/Masaüstü/$ISH_PACKAGE_NAME"
+      "$owner_home/İndirilenler/$ISH_PACKAGE_NAME"
+    )
+  fi
+
+  if [[ -n ${ASUS_ISH_FW_EXE:-} ]]; then
+    candidates=("$ASUS_ISH_FW_EXE" "${candidates[@]}")
+  fi
+
+  for candidate in "${candidates[@]}"; do
+    if [[ -f $candidate ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Re-upload the firmware without a reboot. Safe: intel_ish_ipc only owns the
+# ISH PCI function; unloading it tears the ishtp client devices down and the
+# reload enumerates them again with the new image.
+ish_reload_driver() {
+  # Not "lsmod | grep -q": under pipefail grep's early exit can fail the pipe.
+  [[ -d /sys/module/intel_ish_ipc ]] || return 1
+  modprobe -r intel_ish_ipc 2>/dev/null || return 1
+  modprobe intel_ish_ipc 2>/dev/null || return 1
+  local i
+  for i in $(seq 1 20); do
+    ish_running && return 0
+    sleep 0.5
+  done
+  return 1
+}
+
+module_install_state() {
+  local path
+  if ! ish_is_supported_model; then
+    echo not-installed
+    return
+  fi
+  path="$(ish_fw_path)"
+  if [[ -f $path ]]; then
+    if ish_file_verified "$path"; then
+      echo up-to-date
+    else
+      echo update-available
+    fi
+  else
+    echo not-installed
+  fi
+}
+
+module_install() {
+  local path package package_hash archive image image_hash tmp
+
+  if ! ish_is_supported_model; then
+    warn "[ish-firmware] this module only supports ASUS $ISH_MODEL (the image is ASUS-signed for this board)"
+    return 10
+  fi
+
+  path="$(ish_fw_path)"
+  if [[ ${path##*/} != "$ISH_FW_FALLBACK_NAME" ]]; then
+    warn "[ish-firmware] DMI-derived name ${path##*/} differs from the verified $ISH_FW_FALLBACK_NAME; installing under both"
+  fi
+
+  if ish_file_verified "$path"; then
+    ok "[ish-firmware] verified image already present: $path"
+  else
+    ish_require_tools
+    tmp="$(mktemp -d -t asus-ish-fw.XXXXXXXX)"
+    trap '[[ -n ${tmp:-} ]] && rm -rf -- "$tmp"' EXIT
+
+    package="$(ish_find_local_package || true)"
+    if [[ -n $package ]]; then
+      package_hash="$(sha256sum "$package" | awk '{print $1}')"
+      if [[ $package_hash != "$ISH_PACKAGE_SHA256" ]]; then
+        warn "[ish-firmware] ignoring local package with unexpected SHA-256: $package"
+        package=""
+      else
+        log "[ish-firmware] using verified local package: $package"
+      fi
+    fi
+
+    if [[ -z $package ]]; then
+      package="$tmp/$ISH_PACKAGE_NAME"
+      log "[ish-firmware] downloading the fixed ASUS Intel Sensor Hub V5.8.62.0 package (5 MB, no version lookup)"
+      curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 \
+        --output "$package" "$ISH_PACKAGE_URL"
+      package_hash="$(sha256sum "$package" | awk '{print $1}')"
+      [[ $package_hash == "$ISH_PACKAGE_SHA256" ]] || \
+        die "[ish-firmware] downloaded package SHA-256 mismatch; refusing to install"
+    fi
+
+    archive="$tmp/ish-payload.7z"
+    dd if="$package" of="$archive" iflag=skip_bytes,count_bytes \
+      skip="$ISH_PAYLOAD_OFFSET" count="$ISH_PAYLOAD_SIZE" status=none
+    install -d -m 0700 "$tmp/extracted"
+    7z x -y "-o$tmp/extracted" "$archive" >/dev/null
+
+    image="$(find "$tmp/extracted" -type f -name "$ISH_FW_IMAGE_NAME" -print -quit)"
+    [[ -n $image ]] || die "[ish-firmware] verified package did not contain $ISH_FW_IMAGE_NAME"
+    image_hash="$(sha256sum "$image" | awk '{print $1}')"
+    [[ $image_hash == "$ISH_FW_SHA256" ]] || \
+      die "[ish-firmware] firmware image SHA-256 mismatch; refusing to install"
+
+    log "[ish-firmware] installing -> $path"
+    install -D -m 0644 "$image" "$path"
+    if [[ ${path##*/} != "$ISH_FW_FALLBACK_NAME" ]]; then
+      install -D -m 0644 "$image" "$ISH_FW_DIR/$ISH_FW_FALLBACK_NAME"
+    fi
+  fi
+
+  if ish_running; then
+    ok "[ish-firmware] ISH firmware is running (ishtp client devices present)"
+  elif ish_reload_driver; then
+    ok "[ish-firmware] ISH firmware loaded without a reboot"
+  else
+    echo "Reboot to let the kernel upload the new ISH image."
+  fi
+
+  local als
+  if als="$(ish_als_dev)"; then
+    ok "[ish-firmware] ambient light sensor present: ${als##*/} (name=als) — keyboard-backlight-auto can use it"
+  else
+    echo "No iio 'als' device yet; check './patch.sh status ish-firmware' after the reload/reboot."
+  fi
+}
+
+module_post_uninstall() {
+  local path
+  path="$(ish_fw_path)"
+  rm -f -- "$path" "$ISH_FW_DIR/$ISH_FW_FALLBACK_NAME"
+  echo "Removed the ASUS ISH image. Reboot (or reload intel_ish_ipc) to return to the"
+  echo "generic linux-firmware image, which this board rejects; the 'als' device will disappear."
+}
+
+module_status_extra() {
+  local path kmsg loaded failed base als raw scale lux n=0 d
+
+  path="$(ish_fw_path)"
+  printf '  expected: %s\n' "$path"
+  if ! ish_is_supported_model; then
+    printf '  model:    %snot applicable to this computer%s\n' "$c_dim" "$c_off"
+    return
+  fi
+
+  if ish_file_verified "$path"; then
+    printf '  image:    %sverified ASUS-signed %s%s\n' "$c_ok" "$MODULE_VERSION" "$c_off"
+  elif [[ -f $path ]]; then
+    printf '  image:    %spresent but SHA-256 differs from the verified ASUS image%s\n' "$c_warn" "$c_off"
+  else
+    printf '  image:    %snot installed — kernel falls back to generic ish_ptl.bin%s\n' "$c_warn" "$c_off"
+  fi
+
+  # Only the last loader attempt matters: a reload after uninstall leaves an
+  # older successful "FW base version" line above the newer failure.
+  kmsg="$(journalctl -k -b 0 --no-pager 2>/dev/null | grep 'ISH loader' || true)"
+  kmsg="$(awk '/ISH loader: load firmware:/ {buf=""} {buf=buf $0 "\n"} END {printf "%s", buf}' <<<"$kmsg")"
+  loaded="$(sed -n 's/.*ISH loader: load firmware: \(.*\)$/\1/p' <<<"$kmsg" | tail -n1)"
+  base="$(sed -n 's/.*ISH loader: FW base version: \(.*\)$/\1/p' <<<"$kmsg" | tail -n1)"
+  failed="$(grep -c 'ISH loader: cmd [0-9]* failed' <<<"$kmsg" || true)"
+  if [[ -n $base ]]; then
+    printf '  loader:   %s%s → FW %s%s\n' "$c_ok" "${loaded:-?}" "$base" "$c_off"
+  elif [[ -n $loaded ]]; then
+    printf '  loader:   %s%s rejected (%s failed attempts this boot)%s\n' "$c_warn" "$loaded" "${failed:-?}" "$c_off"
+  else
+    printf '  loader:   %sno ISH loader message this boot (driver not loaded?)%s\n' "$c_dim" "$c_off"
+  fi
+
+  for d in /sys/bus/ishtp/devices/*; do
+    [[ -e $d ]] && n=$(( n + 1 ))
+  done
+  if (( n > 0 )); then
+    printf '  ishtp:    %s%d client devices enumerated%s\n' "$c_ok" "$n" "$c_off"
+  else
+    printf '  ishtp:    %sno client devices — firmware not running%s\n' "$c_warn" "$c_off"
+  fi
+
+  if als="$(ish_als_dev)"; then
+    raw="$(cat "$als/in_illuminance_raw" 2>/dev/null || echo 0)"
+    scale="$(cat "$als/in_illuminance_scale" 2>/dev/null || echo 1)"
+    lux="$(awk -v r="$raw" -v s="$scale" 'BEGIN{printf "%.1f", r*s}')"
+    printf '  als:      %s%s reading %s lux%s\n' "$c_ok" "${als##*/}" "$lux" "$c_off"
+  else
+    printf '  als:      %sno iio als device%s\n' "$c_warn" "$c_off"
+  fi
+}

--- a/keyboard-backlight-auto/README.md
+++ b/keyboard-backlight-auto/README.md
@@ -144,7 +144,10 @@ A visible consequence: `systemd-backlight@leds:asus::kbd_backlight` saves `0`
 at every shutdown and restores a dark keyboard at every boot. The service is
 ordered `After=` it so the curve gets the last word.
 
-**The sensor.** `iio:device1` (`name` = `als`), read through
+**The sensor.** `iio:device1` (`name` = `als`), a HID sensor behind the Intel
+Sensor Hub. It only exists once the ISH runs ASUS's signed firmware image — on a
+stock install the kernel's generic `ish_ptl.bin` is rejected and no `als` device
+ever appears. Install [`ish-firmware`](../ish-firmware/) first. The device is read through
 `in_illuminance_raw` with the driver's `in_illuminance_scale` applied. Read
 directly from sysfs rather than through iio-sensor-proxy's D-Bus API: the raw
 attribute stays readable even while the proxy holds the IIO buffer claimed,

--- a/scripts/check-hardware.sh
+++ b/scripts/check-hardware.sh
@@ -159,7 +159,35 @@ else
 fi
 echo
 
-# 9) Ambient light sensor + keyboard backlight
+# 9) Intel Sensor Hub firmware (the ambient light sensor lives behind it)
+printf '%sIntel Sensor Hub (ISH)%s\n' "$c_bold" "$c_off"
+ish_pci=""
+for d in /sys/bus/pci/devices/*; do
+  [[ "$(cat "$d/vendor" 2>/dev/null)" == "0x8086" && "$(cat "$d/device" 2>/dev/null)" == "0xe445" ]] || continue
+  ish_pci="${d##*/}"; break
+done
+if [[ -n $ish_pci ]]; then
+  ish_vendor=$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || echo '')
+  ish_family=$(cat /sys/class/dmi/id/product_family 2>/dev/null || echo '')
+  ish_name=""
+  if command -v python3 >/dev/null 2>&1 && [[ -n $ish_vendor && -n $ish_family ]]; then
+    ish_name="$(python3 -c 'import sys,zlib; print("ish_ptl_%08x_%08x.bin" % (zlib.crc32(sys.argv[1].encode()), zlib.crc32(sys.argv[2].encode())))' "$ish_vendor" "$ish_family" 2>/dev/null)"
+  fi
+  ish_clients=0
+  for d in /sys/bus/ishtp/devices/*; do [[ -e $d ]] && ish_clients=$(( ish_clients + 1 )); done
+  if (( ish_clients > 0 )); then
+    ok "ISH $ish_pci (8086:e445) firmware running — $ish_clients ishtp client devices"
+  elif [[ -n $ish_name && -f /lib/firmware/intel/ish/$ish_name ]]; then
+    warn "ISH $ish_pci: $ish_name is installed but no ishtp client devices yet — reboot (or reload intel_ish_ipc)"
+  else
+    warn "ISH $ish_pci: no ishtp client devices and no per-OEM image ${ish_name:-ish_ptl_<vendor>_<family>.bin} — ish-firmware applies (needed for the ambient light sensor)"
+  fi
+else
+  note "no Intel Sensor Hub 8086:e445 on PCI — ish-firmware does not apply"
+fi
+echo
+
+# 10) Ambient light sensor + keyboard backlight
 printf '%sAmbient light sensor / keyboard backlight%s\n' "$c_bold" "$c_off"
 als_dev=""
 for d in /sys/bus/iio/devices/iio:device*; do
@@ -174,7 +202,7 @@ if [[ -n $als_dev ]]; then
   als_lux="$(awk -v r="$als_raw" -v s="$als_scale" 'BEGIN{printf "%.1f", r*s}')"
   ok "iio 'als' at ${als_dev##*/} reading ${als_lux} lux — keyboard-backlight-auto applies"
 else
-  note "no iio 'als' device — keyboard-backlight-auto has nothing to read"
+  note "no iio 'als' device — keyboard-backlight-auto has nothing to read (see the ISH line above; ish-firmware provides it)"
 fi
 if [[ -w /sys/class/leds/asus::kbd_backlight/brightness || -e /sys/class/leds/asus::kbd_backlight/brightness ]]; then
   ok "asus::kbd_backlight LED present (max $(cat /sys/class/leds/asus::kbd_backlight/max_brightness 2>/dev/null || echo '?'))"
@@ -184,7 +212,7 @@ else
 fi
 echo
 
-# 10) Distro
+# 11) Distro
 printf '%sDistro%s\n' "$c_bold" "$c_off"
 if [[ -f /etc/arch-release ]]; then
   ok "Arch (or derivative) — patcher's pacman + paths assumed correct"


### PR DESCRIPTION
Closes #9.

## What

On a stock install this B9406CAA has no iio `als` device: the ambient light sensor is a HID sensor behind the Intel Sensor Hub (`00:12.0`, `8086:e445`), the kernel's generic `intel/ish/ish_ptl.bin` is rejected (`ISH loader: cmd 2 failed 10`), and linux-firmware ships no ASUS image under the per-OEM name the loader requests first (`ish_ptl_<crc32(sys_vendor)>_<crc32(product_family)>.bin` → `ish_ptl_59b8d9f2_84881981.bin`). So `keyboard-backlight-auto` has nothing to read. Full evidence in #9 and in `ish-firmware/README.md`.

This adds:

- **`ish-firmware/`** — a runtime-managed module built on the `camera-firmware` pattern: uses a verified local copy of ASUS's fixed *Intel Sensor Hub V5.8.62.0* package or downloads it from ASUS (5 MB, pinned SHA-256), carves the embedded 7z resource at its fixed offset, pins the SHA-256 of `AsusSign_ishS_SI_B9406CAA_5.8.1.7783.bin`, installs it under the DMI-derived name (falls back to the constant without `python3`), reloads `intel_ish_ipc` so no reboot is needed, and reports the `als` device. Refuses on any other `board_name` because the image is signed for this board. Nothing is flashed; nothing ASUS-owned is redistributed.
- **`scripts/check-hardware.sh`** — an *Intel Sensor Hub* section that distinguishes running / installed-but-not-running / missing, and points the existing "no iio als" note at it.
- **`keyboard-backlight-auto/README.md`** — the `als` device is a prerequisite that `ish-firmware` provides.
- **`README.md`** — probe-table row, before/after row, module section 10, module count.

`docs/index.html` is untouched; happy to add the same row there if you want it in this PR.

## Tested (B9406CAA, BIOS 312, CachyOS, Linux 7.2.3-1-cachyos, linux-firmware 20260810)

- `install` with the image absent: download → hash checks → install → `intel_ish_ipc` reload → 5 ishtp client devices, `iio:device1 = als` reading 24.8 lux, no reboot.
- `install` with the image present but the ISH not running: reload path only.
- `install` with everything already right: reports present/running, records the version.
- `uninstall`: removes the file; after a driver reload the loader falls back to the generic image and fails as before (i.e. the change is fully reversible).
- `status` in all three states; `check-hardware.sh` in the missing / installed-not-running / running states.
- `keyboard-backlight-auto` keeps working across the reload (`24.8 lux | bucket 3 | level 2/3`).
- Reboot: the loader picks `ish_ptl_59b8d9f2_84881981.bin` at boot, `FW base version: 5.8.1.7783`.

Hashes: EXE `ae21b72de686cb29c9f184cfe60680ff52728bacfaeb1e2ead3fbffd792224b3`, image `3f5c273dd625eaff9ef2fba95600563e14c1d7d357fa10b7de8c2dc5de3b7e51`, 7z payload at offset 4283536, size 1059104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kymxx2Cm33xsK3QngRMBSR
