### PR TITLE
feat: add platform shim, port intel-perf-fix to Debian/Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,11 +662,12 @@ operations know whether each module is `up to date`, `update available`,
   |---|---|---|
   | `touchpad-fix` | works | config files only, nothing distro-specific |
   | `wifi-fix` | works | config files only |
+  | `keyboard-backlight-auto` | works | config files plus a python3 daemon and its unit; no package manager involved |
   | `intel-perf-fix` | partial | `thermald` works. `intel-lpmd` is absent on Debian and, on Ubuntu 24.04, too old (0.0.3) to recognise Panther Lake — it installs and exits at once. Both cases are reported, not hidden |
   | `display-fix` | not yet | needs the cmdline backend wired into the module |
   | `audio-fix` | not yet | DKMS builds, but the `NoExtract` UCM pin has no direct equivalent (closest is `dpkg-divert`) |
   | `camera-firmware` | not yet | needs `fwupd`, `jq`, `7z`, `curl` mapped to Debian names |
-  | `webcam-ai-fix`, `keyboard-backlight-fix` | not planned | depend on AUR-only packages (`obs-backgroundremoval`, `asusctl`) |
+  | `webcam-ai-fix`, `keyboard-backlight-fix` | not planned | depend on AUR-only packages (`obs-backgroundremoval`, `asusctl`); `keyboard-backlight-fix` is superseded by `keyboard-backlight-auto` anyway |
 
   Tracking issue: [#4](https://github.com/burakgon/asus-expertbook-linux/issues/4).
 - **Bootloader assumption (display-fix):** `limine` via

--- a/README.md
+++ b/README.md
@@ -388,11 +388,18 @@ all idle work concentrates on a single LP-E core and the P-cores deep-sleep.
 | `thermald` | `extra` | `main` | `thermald.service` | P/E-core-aware thermal throttle. |
 | `intel-lpmd` | `extra` / `cachyos` | `universe` (Ubuntu 24.04+); **not in Debian** | `intel_lpmd.service` | Parks idle work on LP-E core, lets P-cores deep-sleep. |
 
-The package names happen to match across both families. Where `intel-lpmd`
-is missing the module says so and installs `thermald` alone rather than
-failing — half the win is still worth having. The service unit name is
-resolved at runtime (`svc_unit`) instead of hardcoded, because it is a
-packaging decision each distribution makes independently.
+The package names happen to match across both families, and so does the unit
+name — though it is resolved at runtime (`svc_unit`) rather than hardcoded,
+because that is a packaging decision each distribution makes independently.
+
+**On Debian and Ubuntu you get the thermald half only, for now.** Debian has no
+`intel-lpmd` package at all. Ubuntu 24.04 has one, but it is 0.0.3 (February
+2024), which predates Panther Lake: it installs, the unit enables, and the
+daemon exits within milliseconds on CPU family 6 model 204 without logging a
+reason. Verified on Pop!_OS 24.04. The module reports this at install time and
+in `status` instead of leaving you to believe the idle-power win is active. The
+unit is left enabled on purpose, so a later package upgrade starts working
+without re-running anything.
 
 Both coexist with the existing `power-profiles-daemon` (PPD handles user
 profile, thermald handles thermal, intel-lpmd handles idle topology).
@@ -655,7 +662,7 @@ operations know whether each module is `up to date`, `update available`,
   |---|---|---|
   | `touchpad-fix` | works | config files only, nothing distro-specific |
   | `wifi-fix` | works | config files only |
-  | `intel-perf-fix` | works | `thermald` in main; `intel-lpmd` in Ubuntu universe, absent on Debian and skipped with a warning |
+  | `intel-perf-fix` | partial | `thermald` works. `intel-lpmd` is absent on Debian and, on Ubuntu 24.04, too old (0.0.3) to recognise Panther Lake — it installs and exits at once. Both cases are reported, not hidden |
   | `display-fix` | not yet | needs the cmdline backend wired into the module |
   | `audio-fix` | not yet | DKMS builds, but the `NoExtract` UCM pin has no direct equivalent (closest is `dpkg-divert`) |
   | `camera-firmware` | not yet | needs `fwupd`, `jq`, `7z`, `curl` mapped to Debian names |

--- a/README.md
+++ b/README.md
@@ -39,12 +39,14 @@ curl -fsSL https://raw.githubusercontent.com/burakgon/asus-expertbook-linux/main
 | Audio codec | Cirrus `CS42L43` + 2× `CS35L56` (subsystem `1043:15e4`) | Per-OEM speaker firmware needed |
 | Wi-Fi card | Intel Wi-Fi 7 `BE211` (`8086:e440`) | iwlmld-mode tunables apply here |
 | Ambient light sensor | `iio` device named `als` with `in_illuminance_raw` | `keyboard-backlight-auto` reads it to drive the keyboard backlight |
-| Distro | Arch / CachyOS / any Arch-derivative | The patcher uses `pacman` and reads `/etc` paths Arch-style |
+| Distro | Arch / CachyOS / any Arch-derivative — Debian / Ubuntu / Pop!_OS partially | Every module works on Arch; on Debian families see the [support table](#kernel--distro-compatibility) |
 
 If you're on a sibling model (`104315d4` / `104315f4`) and willing to test, see
 [Adding a new module / model](#adding-a-new-module-or-model). If you're on a
-different distro, the modules themselves still apply — only the
-`pacman`-based package-install steps are Arch-specific.
+Debian-family distro, see the per-module status in
+[Kernel & distro compatibility](#kernel--distro-compatibility) — the config-file
+modules apply as-is, and the package-installing ones are being ported one at a
+time via [`lib/distro.sh`](lib/distro.sh).
 
 ## What this actually fixes — before / after
 
@@ -381,17 +383,25 @@ all idle work concentrates on a single LP-E core and the P-cores deep-sleep.
 
 <details><summary><b>The fix</b> — install + enable thermald and intel-lpmd</summary>
 
-| Package | Source | Service | Effect |
-|---|---|---|---|
-| `thermald` | `extra` repo | `thermald.service` | P/E-core-aware thermal throttle. |
-| `intel-lpmd` | `extra` / `cachyos` repo | `intel_lpmd.service` | Parks idle work on LP-E core, lets P-cores deep-sleep. |
+| Package | Arch source | Debian/Ubuntu source | Service | Effect |
+|---|---|---|---|---|
+| `thermald` | `extra` | `main` | `thermald.service` | P/E-core-aware thermal throttle. |
+| `intel-lpmd` | `extra` / `cachyos` | `universe` (Ubuntu 24.04+); **not in Debian** | `intel_lpmd.service` | Parks idle work on LP-E core, lets P-cores deep-sleep. |
+
+The package names happen to match across both families. Where `intel-lpmd`
+is missing the module says so and installs `thermald` alone rather than
+failing — half the win is still worth having. The service unit name is
+resolved at runtime (`svc_unit`) instead of hardcoded, because it is a
+packaging decision each distribution makes independently.
 
 Both coexist with the existing `power-profiles-daemon` (PPD handles user
 profile, thermald handles thermal, intel-lpmd handles idle topology).
 
 This module ships **no payload files** — it's purely package install + service
 enable in the post-install hook. The patcher tracks it the same way it
-tracks file-based modules (versioned, idempotent, status-checked).
+tracks file-based modules (versioned, idempotent, status-checked). Package and
+service calls go through [`lib/distro.sh`](lib/distro.sh), so the same hook
+runs unchanged on pacman and apt systems.
 
 </details>
 
@@ -594,6 +604,8 @@ asus-expertbook-linux/
 ├── wifi-fix/  …
 ├── upstream-patches/           # accepted/pending/retired upstream tracking
 │   └── 0001, 0003, 0004.patch
+├── lib/
+│   └── distro.sh               # package manager / initramfs / bootloader / services
 ├── docs/                       # the GitHub Pages site
 └── scripts/
     └── check-hardware.sh       # one-shot compatibility check
@@ -633,10 +645,30 @@ operations know whether each module is `up to date`, `update available`,
   all use the same `/etc/udev/hwdb.d`, `/etc/libinput`,
   `/etc/modprobe.d`, `/etc/wireplumber/wireplumber.conf.d` paths the
   modules write to.
+- **Debian / Ubuntu / Pop!_OS:** partial, and being added one module at a
+  time. [`lib/distro.sh`](lib/distro.sh) abstracts the package manager,
+  kernel-header discovery, initramfs regeneration, kernel-cmdline backend and
+  service enablement, so a module written against those helpers runs on both
+  families. Ported so far:
+
+  | Module | Debian/Ubuntu | Note |
+  |---|---|---|
+  | `touchpad-fix` | works | config files only, nothing distro-specific |
+  | `wifi-fix` | works | config files only |
+  | `intel-perf-fix` | works | `thermald` in main; `intel-lpmd` in Ubuntu universe, absent on Debian and skipped with a warning |
+  | `display-fix` | not yet | needs the cmdline backend wired into the module |
+  | `audio-fix` | not yet | DKMS builds, but the `NoExtract` UCM pin has no direct equivalent (closest is `dpkg-divert`) |
+  | `camera-firmware` | not yet | needs `fwupd`, `jq`, `7z`, `curl` mapped to Debian names |
+  | `webcam-ai-fix`, `keyboard-backlight-fix` | not planned | depend on AUR-only packages (`obs-backgroundremoval`, `asusctl`) |
+
+  Tracking issue: [#4](https://github.com/burakgon/asus-expertbook-linux/issues/4).
 - **Bootloader assumption (display-fix):** `limine` via
   `limine-mkinitcpio-hook`, where `/etc/limine-entry-tool.d/` drop-ins are the
   source of truth. If you use systemd-boot or GRUB, the module's
   cmdline-injection hook needs swapping; the modprobe.d half still works.
+  `lib/distro.sh` already implements all three backends
+  (`cmdline_backend` → `limine` | `kernelstub` | `grub`); the module itself
+  has not been migrated onto them yet.
 
 ## Adding a new module or model
 
@@ -657,6 +689,34 @@ module_post_install()   { …; }   # optional
 module_post_uninstall() { …; }   # optional
 module_status_extra()   { …; }   # optional
 ```
+
+### Platform helpers
+
+Hooks run in a subshell that inherits everything `patch.sh` defines, including
+[`lib/distro.sh`](lib/distro.sh). Use these instead of calling `pacman`,
+`mkinitcpio`, `limine-update` or `systemctl` directly, and the module works on
+Arch and Debian families alike:
+
+| Helper | Does |
+|---|---|
+| `distro_family` | `arch` \| `debian` \| `unknown` (reads `ID` *and* `ID_LIKE`) |
+| `pkg_manager` | `pacman` \| `apt` \| `none` |
+| `pkg_install <pkg>…` | `pacman -S --needed --noconfirm` / `apt-get install -y` |
+| `pkg_version <pkg>` | installed version, empty when absent |
+| `pkg_installed` / `pkg_available` | is it installed / known to the repos |
+| `pkg_atleast <pkg> <ver>` | version comparison, for gating bundled payloads |
+| `pkg_remove_hint <pkg>…` | the removal command to print for the user |
+| `kernel_list` | installed kernel releases, one per line |
+| `kernel_headers_present [kver]` / `kernel_headers_install [kver]` | DKMS prerequisites |
+| `initramfs_regen [reason]` | `limine-mkinitcpio` → `mkinitcpio -P` → `update-initramfs` → `dracut` |
+| `cmdline_backend` | `limine` \| `kernelstub` \| `grub` \| `none` |
+| `cmdline_add` / `cmdline_remove <param>…` | idempotent kernel-parameter edits |
+| `cmdline_active` / `cmdline_active_value` / `cmdline_configured` | what is live vs. staged |
+| `svc_unit <candidate>…` | resolve a unit name that differs between distros |
+| `svc_enable_now` / `svc_disable_now` / `svc_is_active` / `svc_exists` | systemd |
+
+Testing overrides — never set these in normal use: `GRUB_FILE`,
+`KERNELSTUB_FILE`, `LIMINE_DROPIN_DIR`, `CMDLINE_BACKEND`.
 
 Sibling-model contributions for `1043:15d4` and `1043:15f4` ExpertBook
 Ultra variants are very welcome — open a PR with your subsystem ID's

--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ operations know whether each module is `up to date`, `update available`,
   | `keyboard-backlight-auto` | works | config files plus a python3 daemon and its unit; no package manager involved |
   | `intel-perf-fix` | partial | `thermald` works. `intel-lpmd` is absent on Debian and, on Ubuntu 24.04, too old (0.0.3) to recognise Panther Lake — it installs and exits at once. Both cases are reported, not hidden |
   | `display-fix` | not yet | needs the cmdline backend wired into the module |
-  | `audio-fix` | not yet | DKMS builds, but the `NoExtract` UCM pin has no direct equivalent (closest is `dpkg-divert`) |
+  | `audio-fix` | not yet | Three blockers, all measured on Pop!_OS 24.04. The DKMS source compiles cleanly against a current kernel, but `dkms.conf` hardcodes `LLVM=1` and `audio_require_build_tools` demands `clang`, while Debian-family kernels are `CONFIG_CC_IS_GCC`. The per-kernel `dkms install` loop aborts the whole install on the first kernel whose API the source predates — not Debian-specific; `audio-fix` has neither the `BUILD_EXCLUSIVE_KERNEL` guard nor the skip-and-warn that #12 uses. And the bundled UCM files declare Syntax 7, which needs alsa-lib >= 1.2.12; Ubuntu 24.04 ships 1.2.11, so installing them breaks UCM for the whole `sof-soundwire` family. The `NoExtract` pin maps to `dpkg-divert` |
   | `camera-firmware` | not yet | needs `fwupd`, `jq`, `7z`, `curl` mapped to Debian names |
   | `webcam-ai-fix`, `keyboard-backlight-fix` | not planned | depend on AUR-only packages (`obs-backgroundremoval`, `asusctl`); `keyboard-backlight-fix` is superseded by `keyboard-backlight-auto` anyway |
 

--- a/audio-fix/module.sh
+++ b/audio-fix/module.sh
@@ -80,16 +80,10 @@ UCM_FILES=(
 )
 
 # ucm_hifi_is_upstream: true when the installed alsa-ucm-conf already ships the
-# combined cs35l56+cs42l43-spk HiFi UCM (>= 1.2.16). On non-pacman systems we
-# can't tell, so we return false and install the bundled copies.
+# combined cs35l56+cs42l43-spk HiFi UCM (>= 1.2.16). Falls back to false when
+# the version cannot be determined, and we install the bundled copies.
 ucm_hifi_is_upstream() {
-  command -v pacman >/dev/null 2>&1 || return 1
-  local v lowest
-  v="$(pacman -Q alsa-ucm-conf 2>/dev/null | awk '{print $2}')"
-  v="${v%%-*}"
-  [[ -n $v ]] || return 1
-  lowest="$(printf '%s\n%s\n' "1.2.16" "$v" | sort -V | sed -n '1p')"
-  [[ $lowest == 1.2.16 ]]
+  pkg_atleast alsa-ucm-conf 1.2.16
 }
 
 # audio_kernel_has_upstream_ghost_quirk [kernel-release]
@@ -170,34 +164,23 @@ audio_remove_legacy_dkms() {
 }
 
 audio_require_build_tools() {
-  local missing=() package
-  for package in dkms make clang; do
-    command -v "$package" >/dev/null 2>&1 || missing+=("$package")
+  local missing=() tool
+  for tool in dkms make clang; do
+    command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
   done
 
   if (( ${#missing[@]} > 0 )); then
-    if command -v pacman >/dev/null 2>&1; then
-      log "[audio-fix] installing required build tools: ${missing[*]}"
-      pacman -S --needed --noconfirm "${missing[@]}"
-    else
-      die "[audio-fix] missing build tools: ${missing[*]}"
-    fi
+    log "[audio-fix] installing required build tools: ${missing[*]}"
+    pkg_install "${missing[@]}" || die "[audio-fix] missing build tools: ${missing[*]}"
   fi
 
-  if [[ ! -e /lib/modules/$(uname -r)/build/Makefile ]]; then
-    if command -v pacman >/dev/null 2>&1 && \
-       [[ -r /lib/modules/$(uname -r)/pkgbase ]]; then
-      package="$(<"/lib/modules/$(uname -r)/pkgbase")-headers"
-      log "[audio-fix] installing running-kernel headers: $package"
-      pacman -S --needed --noconfirm "$package"
-    else
-      die "[audio-fix] kernel headers missing for $(uname -r)"
-    fi
-  fi
+  kernel_headers_present || \
+    kernel_headers_install || \
+    die "[audio-fix] kernel headers missing for $(uname -r)"
 }
 
 audio_install_dkms() {
-  local kernel kernel_dir installed=0 needed=0
+  local kernel installed=0 needed=0
   local -a build_kernels=()
 
   [[ -f $AUDIO_DKMS_SOURCE/dkms.conf ]] || \
@@ -220,21 +203,19 @@ audio_install_dkms() {
 
   rm -rf -- "$AUDIO_DKMS_TARGET"
 
-  for kernel_dir in /usr/lib/modules/*; do
-    [[ -d $kernel_dir ]] || continue
-    kernel="${kernel_dir##*/}"
+  while IFS= read -r kernel; do
     if audio_kernel_has_upstream_ghost_quirk "$kernel"; then
       log "[audio-fix] $kernel contains upstream B9406CAA ghost-RT722 quirk; DKMS not needed"
       continue
     fi
 
     needed=$(( needed + 1 ))
-    if [[ ! -e $kernel_dir/build/Makefile ]]; then
+    if ! kernel_headers_present "$kernel"; then
       warn "[audio-fix] skipping $kernel: upstream quirk absent and matching headers are not installed"
       continue
     fi
     build_kernels+=("$kernel")
-  done
+  done < <(kernel_list)
 
   if (( needed == 0 )); then
     log "[audio-fix] every installed kernel contains the upstream DMI quirk; removed redundant DKMS overlay"
@@ -265,13 +246,7 @@ audio_refresh_initramfs() {
   local reason="${1:-after the audio driver change}"
   # sof_sdw may be included in an autodetected initramfs. Rebuild it now so the
   # selected stock/DKMS copy is consistent at the next boot.
-  if command -v limine-mkinitcpio >/dev/null 2>&1; then
-    log "[audio-fix] rebuilding Limine initramfs entries $reason"
-    limine-mkinitcpio
-  elif command -v mkinitcpio >/dev/null 2>&1; then
-    log "[audio-fix] rebuilding initramfs images $reason"
-    mkinitcpio -P
-  fi
+  initramfs_regen "$reason"
 }
 
 audio_remove_dkms() {
@@ -289,11 +264,12 @@ module_post_install() {
   audio_install_dkms
 
   if ucm_hifi_is_upstream; then
-    local v; v="$(pacman -Q alsa-ucm-conf 2>/dev/null | awk '{print $2}')"
+    local v; v="$(pkg_version alsa-ucm-conf)"
     log "[audio-fix] alsa-ucm-conf ${v} ships the cs35l56+cs42l43-spk HiFi UCM upstream -- not installing bundled UCM (firmware-only)."
     # If an older version of this module pinned sof-soundwire.conf via NoExtract,
     # drop the pin so the packaged file tracks future upgrades normally.
-    if grep -q "ucm2/sof-soundwire/sof-soundwire.conf" /etc/pacman.conf 2>/dev/null; then
+    if [[ $(pkg_manager) == pacman ]] && \
+       grep -q "ucm2/sof-soundwire/sof-soundwire.conf" /etc/pacman.conf 2>/dev/null; then
       sed -i '\#ucm2/sof-soundwire/sof-soundwire.conf#d' /etc/pacman.conf
       log "[audio-fix] removed obsolete sof-soundwire.conf NoExtract pin from /etc/pacman.conf"
     fi
@@ -312,7 +288,10 @@ module_post_install() {
     # Pin our sof-soundwire.conf so an alsa-ucm-conf upgrade doesn't revert the
     # SpeakerCodec regex fix. (Re-running this module after the upgrade crosses
     # 1.2.16 drops the pin automatically.)
-    if ! grep -q "ucm2/sof-soundwire/sof-soundwire.conf" /etc/pacman.conf; then
+    # NoExtract is a pacman feature; the Debian analogue is dpkg-divert and is
+    # deliberately not wired up yet.
+    if [[ $(pkg_manager) == pacman ]] && \
+       ! grep -q "ucm2/sof-soundwire/sof-soundwire.conf" /etc/pacman.conf; then
       sed -i '/^#NoExtract/a NoExtract   = usr/share/alsa/ucm2/sof-soundwire/sof-soundwire.conf' /etc/pacman.conf
     fi
   fi
@@ -334,7 +313,9 @@ module_post_uninstall() {
       rm -f -- "$dst"
     done
     rm -f /usr/share/alsa/ucm2/codecs/cs35l56+cs42l43-spk
-    sed -i '\#ucm2/sof-soundwire/sof-soundwire.conf#d' /etc/pacman.conf 2>/dev/null || true
+    if [[ $(pkg_manager) == pacman ]]; then
+      sed -i '\#ucm2/sof-soundwire/sof-soundwire.conf#d' /etc/pacman.conf 2>/dev/null || true
+    fi
     echo "Reboot to revert. Speakers go silent again until upstream alsa-ucm-conf"
     echo "ships the cs35l56+cs42l43-spk UCM (>= 1.2.16)."
   else

--- a/display-fix/module.sh
+++ b/display-fix/module.sh
@@ -88,10 +88,11 @@ module_post_uninstall() {
 }
 
 module_status_extra() {
-  local backlight_value="" token
+  local backlight_value=""
 
-  if grep -Eq '(^| )(xe\.enable_psr=0|xe\.enable_psr2_sel_fetch=0|xe\.enable_panel_replay=0)( |$)' \
-      /proc/cmdline 2>/dev/null; then
+  if cmdline_active xe.enable_psr=0 || \
+     cmdline_active xe.enable_psr2_sel_fetch=0 || \
+     cmdline_active xe.enable_panel_replay=0; then
     printf '  self-refresh:%s legacy =0 override active in this boot — reboot to use kernel defaults%s\n' \
       "$c_warn" "$c_off"
   else
@@ -99,11 +100,7 @@ module_status_extra() {
       "$c_ok" "$c_off"
   fi
 
-  while IFS= read -r token; do
-    if [[ $token == xe.enable_dpcd_backlight=* ]]; then
-      backlight_value="${token#*=}"
-    fi
-  done < <(tr ' ' '\n' </proc/cmdline 2>/dev/null)
+  backlight_value="$(cmdline_active_value xe.enable_dpcd_backlight)"
 
   if [[ $backlight_value == 2 ]]; then
     printf '  backlight:%s xe.enable_dpcd_backlight=2 active (forced VESA interface)%s\n' \

--- a/docs/index.html
+++ b/docs/index.html
@@ -433,7 +433,8 @@ Camera firmware
   OK   ASUS 3009 / 10.1.2.3009 baseline satisfied (ESRT raw 479569)
 
 Distro
-  OK   Arch (or derivative) — patcher's pacman + paths assumed correct
+  OK   CachyOS Linux — pacman; every module is supported here
+  package manager: pacman    boot parameters: limine
 
 Result: install-all is appropriate for this hardware.</code></pre>
     </div>
@@ -651,7 +652,7 @@ sudo reboot</code></pre>
   1   audio-fix                3.1.0    3.1.0     up to date     Adaptive ghost-RT722 fix + HiFi audio
   2   camera-firmware          3009     3009      up to date     Verified camera UEFI capsule
   3   display-fix              1.3.0    1.3.0     up to date     Linux 7.2 defaults + DPCD brightness
-  4   intel-perf-fix           1.1.0    1.1.0     up to date     thermald + intel-lpmd
+  4   intel-perf-fix           1.2.0    1.2.0     up to date     thermald + intel-lpmd
   5   keyboard-backlight-auto  1.0.0    1.0.0     up to date     Ambient-light keyboard backlight
   6   keyboard-backlight-fix   2.0.0    -         not installed  (superseded) asusd workaround
   7   touchpad-fix             1.1.1    1.1.1     up to date     PixArt 093A:4F05 pressure quirk
@@ -886,9 +887,16 @@ kwin_wayland: Pageflip timed out! This is a bug in the xe kernel driver</code></
         </p>
         <p><strong>Packages installed (no payload files):</strong></p>
         <ul>
-          <li><code>thermald</code> (extra repo) — <code>thermald.service</code> enabled</li>
-          <li><code>intel-lpmd</code> (extra / cachyos repo, plain pacman) — <code>intel_lpmd.service</code> enabled</li>
+          <li><code>thermald</code> (Arch <code>extra</code>; Debian/Ubuntu <code>main</code>) — <code>thermald.service</code> enabled</li>
+          <li><code>intel-lpmd</code> (Arch <code>extra</code>/<code>cachyos</code>; Ubuntu <code>universe</code>, not in Debian) — <code>intel_lpmd.service</code> enabled</li>
         </ul>
+        <p>
+          This is the first module ported off <code>pacman</code>: package and
+          service calls go through <code>lib/distro.sh</code>, so the same hook
+          runs on apt systems too. Where <code>intel-lpmd</code> is unavailable
+          the module installs <code>thermald</code> alone and says so, rather
+          than failing.
+        </p>
         <p>
           Both daemons coexist with the existing <code>power-profiles-daemon</code>:
           PPD handles user profile, thermald handles thermal, intel-lpmd handles
@@ -1169,6 +1177,18 @@ EC set level 0/3 | manual override active for 0.0-18.4 lux (reading 9.2)</code><
         discoverable module. The patcher records the installed version
         under <code>/var/lib/asus_expertboot_patcher/</code> so subsequent
         operations know whether each module needs an update.
+      </p>
+      <p class="sub">
+        <strong>Distros.</strong> Arch and its derivatives (CachyOS,
+        EndeavourOS, Manjaro) are the reference platform and run every module.
+        Debian, Ubuntu and Pop!_OS are supported incrementally:
+        <code>lib/distro.sh</code> abstracts the package manager, kernel-header
+        discovery, initramfs regeneration, kernel-cmdline backend
+        (Limine / kernelstub / GRUB) and service enablement, and modules are
+        being moved onto it one at a time. Working there today:
+        <code>touchpad-fix</code>, <code>wifi-fix</code> (config files only)
+        and <code>intel-perf-fix</code>. Progress is tracked in
+        <a href="https://github.com/burakgon/asus-expertbook-linux/issues/4">issue&nbsp;#4</a>.
       </p>
 
       <div class="grid grid-2">

--- a/docs/index.html
+++ b/docs/index.html
@@ -893,9 +893,13 @@ kwin_wayland: Pageflip timed out! This is a bug in the xe kernel driver</code></
         <p>
           This is the first module ported off <code>pacman</code>: package and
           service calls go through <code>lib/distro.sh</code>, so the same hook
-          runs on apt systems too. Where <code>intel-lpmd</code> is unavailable
-          the module installs <code>thermald</code> alone and says so, rather
-          than failing.
+          runs on apt systems too. On Debian and Ubuntu only the
+          <code>thermald</code> half currently works: Debian has no
+          <code>intel-lpmd</code> package, and Ubuntu 24.04 ships 0.0.3
+          (February 2024), which predates Panther Lake and exits within
+          milliseconds of starting. The module reports both cases at install
+          time and in <code>status</code> rather than leaving a daemon that
+          looks enabled but is dead.
         </p>
         <p>
           Both daemons coexist with the existing <code>power-profiles-daemon</code>:

--- a/intel-perf-fix/module.sh
+++ b/intel-perf-fix/module.sh
@@ -4,16 +4,19 @@
 # tuning that Omarchy 3.5/3.6 enables out of the box, on KDE Plasma + Arch.
 # Specifically:
 #
-#   thermald (extra repo)   Intel thermal management daemon. P/E core throttle
+#   thermald                Intel thermal management daemon. P/E core throttle
 #                           awareness, much better than the kernel's coarse
 #                           default on Panther Lake's hybrid topology.
+#                           Arch: extra. Debian/Ubuntu: main.
 #
-#   intel-lpmd (extra/      Intel Low Power Mode Daemon. When the system is
-#   cachyos repo)           idle, parks all workload on a single LP-E core and
+#   intel-lpmd              Intel Low Power Mode Daemon. When the system is
+#                           idle, parks all workload on a single LP-E core and
 #                           lets the P-cores deep-sleep — biggest single
 #                           idle-power win on PTL hardware. Stock config is
 #                           Mode 0 (Cgroup v2 cpuset): it confines tasks to the
 #                           LP-E cluster rather than offlining the P-cores.
+#                           Arch: extra/cachyos. Ubuntu: universe (24.04+).
+#                           Not in Debian yet, so its absence is tolerated.
 #
 # We deliberately DO NOT touch:
 #   - The Hyprland-only toggles (Omarchy is Hyprland-based; we run KDE Plasma
@@ -26,62 +29,87 @@
 # This module ships no payload files; everything happens in the install hook
 # (package installs + systemd unit enables). Empty MODULE_FILES is intentional
 # and supported by patch.sh (mod_files_state treats empty as "all").
+#
+# Package and service calls go through lib/distro.sh so the same hook works on
+# pacman and apt systems. The unit name is resolved at runtime rather than
+# hardcoded: intel-lpmd ships as intel_lpmd.service on Arch, and the unit name
+# is a packaging decision each distribution makes independently.
 
 MODULE_NAME="intel-perf-fix"
 MODULE_DESC="Panther Lake thermal + power daemons (thermald, intel-lpmd) à la Omarchy"
-MODULE_VERSION="1.1.0"
+MODULE_VERSION="1.2.0"
 
 MODULE_FILES=()
 
 module_post_install() {
-  echo "  installing thermald (extra repo)"
-  pacman -S --needed --noconfirm thermald 2>&1 | tail -3 || true
+  local unit
 
-  echo "  enabling thermald.service"
-  systemctl enable --now thermald.service 2>&1 | tail -1 || true
+  echo "  installing thermald"
+  pkg_install thermald 2>&1 | tail -3 || true
+
+  unit="$(svc_unit thermald.service)"
+  echo "  enabling $unit"
+  svc_enable_now "$unit" 2>&1 | tail -1 || true
 
   echo
-  echo "  installing intel-lpmd (extra/cachyos repo)"
-  pacman -S --needed --noconfirm intel-lpmd 2>&1 | tail -3 || true
+  if pkg_installed intel-lpmd || pkg_available intel-lpmd; then
+    echo "  installing intel-lpmd"
+    pkg_install intel-lpmd 2>&1 | tail -3 || true
 
-  echo "  enabling intel_lpmd.service"
-  systemctl enable --now intel_lpmd.service 2>&1 | tail -1 || true
+    unit="$(svc_unit intel_lpmd.service intel-lpmd.service)"
+    echo "  enabling $unit"
+    svc_enable_now "$unit" 2>&1 | tail -1 || true
+  else
+    # Debian has no intel-lpmd package (Ubuntu carries it in universe).
+    # thermald alone still covers the thermal half, so a missing intel-lpmd is
+    # a warning rather than a failure. On Arch this branch is unreachable
+    # unless `pacman -Si intel-lpmd` fails, in which case `pacman -S` would
+    # have failed the same way.
+    warn "intel-lpmd is not available on this distribution; skipping it"
+    echo "  thermald alone still covers the thermal half of this module."
+  fi
 }
 
 module_post_uninstall() {
-  echo "  disabling thermald.service"
-  systemctl disable --now thermald.service 2>/dev/null || true
+  local unit
 
-  if systemctl list-unit-files intel_lpmd.service >/dev/null 2>&1; then
-    systemctl disable --now intel_lpmd.service 2>/dev/null && echo "  disabled intel_lpmd.service"
+  unit="$(svc_unit thermald.service)"
+  echo "  disabling $unit"
+  svc_disable_now "$unit" 2>/dev/null || true
+
+  unit="$(svc_unit intel_lpmd.service intel-lpmd.service)"
+  if svc_exists "$unit"; then
+    svc_disable_now "$unit" 2>/dev/null && echo "  disabled $unit"
   fi
 
   echo
   echo "  Packages left installed (so revert is reversible without re-fetching)."
   echo "  Remove fully with:"
-  echo "    sudo pacman -Rns thermald"
-  echo "    sudo pacman -Rns intel-lpmd"
+  echo "    $(pkg_remove_hint thermald)"
+  echo "    $(pkg_remove_hint intel-lpmd)"
 }
 
 module_status_extra() {
-  local s
-  for svc in thermald.service intel_lpmd.service; do
+  local s svc version
+
+  for svc in "$(svc_unit thermald.service)" \
+             "$(svc_unit intel_lpmd.service intel-lpmd.service)"; do
+    # `systemctl is-active` answers "inactive" for a unit that does not exist,
+    # so ask svc_exists instead — the silent case the original code intended.
+    svc_exists "$svc" || continue
     s="$(systemctl is-active "$svc" 2>/dev/null || true)"
     case "$s" in
-      active)        printf '  %-22s %sactive%s\n' "$svc" "$c_ok" "$c_off" ;;
+      active)          printf '  %-22s %sactive%s\n' "$svc" "$c_ok" "$c_off" ;;
       inactive|failed) printf '  %-22s %s%s%s\n' "$svc" "$c_warn" "$s" "$c_off" ;;
-      "") ;;  # service unit doesn't exist; silent
     esac
   done
 
-  if pacman -Q thermald >/dev/null 2>&1; then
-    printf '  thermald pkg:          %s%s%s\n' "$c_ok" "$(pacman -Q thermald | awk '{print $2}')" "$c_off"
-  else
-    printf '  thermald pkg:          %snot installed%s\n' "$c_warn" "$c_off"
-  fi
-  if pacman -Q intel-lpmd >/dev/null 2>&1; then
-    printf '  intel-lpmd pkg:        %s%s%s\n' "$c_ok" "$(pacman -Q intel-lpmd | awk '{print $2}')" "$c_off"
-  else
-    printf '  intel-lpmd pkg:        %snot installed%s\n' "$c_warn" "$c_off"
-  fi
+  for svc in thermald intel-lpmd; do
+    version="$(pkg_version "$svc")"
+    if [[ -n $version ]]; then
+      printf '  %-22s %s%s%s\n' "$svc pkg:" "$c_ok" "$version" "$c_off"
+    else
+      printf '  %-22s %snot installed%s\n' "$svc pkg:" "$c_warn" "$c_off"
+    fi
+  done
 }

--- a/intel-perf-fix/module.sh
+++ b/intel-perf-fix/module.sh
@@ -17,6 +17,10 @@
 #                           LP-E cluster rather than offlining the P-cores.
 #                           Arch: extra/cachyos. Ubuntu: universe (24.04+).
 #                           Not in Debian yet, so its absence is tolerated.
+#                           Caveat: Ubuntu 24.04 ships 0.0.3 (Feb 2024), which
+#                           exits immediately on Panther Lake (family 6 model
+#                           204) because it predates it. Verified on Pop!_OS
+#                           24.04. The install hook reports this.
 #
 # We deliberately DO NOT touch:
 #   - The Hyprland-only toggles (Omarchy is Hyprland-based; we run KDE Plasma
@@ -59,6 +63,18 @@ module_post_install() {
     unit="$(svc_unit intel_lpmd.service intel-lpmd.service)"
     echo "  enabling $unit"
     svc_enable_now "$unit" 2>&1 | tail -1 || true
+
+    # intel_lpmd exits immediately on a CPU model it predates, without logging
+    # a reason. Ubuntu 24.04 ships 0.0.3 (Feb 2024), which does not know
+    # Panther Lake, so the unit enables and the daemon is dead a few ms later.
+    # Say so instead of leaving the user thinking they got the idle-power win.
+    if ! svc_is_active "$unit"; then
+      warn "$unit was enabled but is not running"
+      echo "  intel-lpmd $(pkg_version intel-lpmd) exits on CPU models it does not"
+      echo "  recognise. Panther Lake needs a newer release than this distribution"
+      echo "  ships. The unit stays enabled, so a later package upgrade starts"
+      echo "  working without re-running this module."
+    fi
   else
     # Debian has no intel-lpmd package (Ubuntu carries it in universe).
     # thermald alone still covers the thermal half, so a missing intel-lpmd is
@@ -112,4 +128,11 @@ module_status_extra() {
       printf '  %-22s %snot installed%s\n' "$svc pkg:" "$c_warn" "$c_off"
     fi
   done
+
+  # Explain a dead intel_lpmd rather than leaving a bare "inactive" above.
+  svc="$(svc_unit intel_lpmd.service intel-lpmd.service)"
+  if svc_exists "$svc" && ! svc_is_active "$svc" && pkg_installed intel-lpmd; then
+    printf '  %-22s %sinstalled but exits at startup — too old for this CPU%s\n' \
+      "intel-lpmd:" "$c_warn" "$c_off"
+  fi
 }

--- a/lib/distro.sh
+++ b/lib/distro.sh
@@ -289,20 +289,54 @@ _grub_options() {
     "$GRUB_FILE" | tail -n1
 }
 
+# _grub_write_options <new-cmdline> -- replace GRUB_CMDLINE_LINUX_DEFAULT.
+#
+# The replacement is atomic. Truncating the live file and rewriting it in place
+# would leave an empty or half-written /etc/default/grub if the write were cut
+# short, which is not a risk worth taking on a bootloader config. Instead the
+# new content is staged beside the target and renamed over it in one step.
+#
+# Two details the obvious version gets wrong:
+#   - the staging file must live in the target's own directory. mktemp defaults
+#     to /tmp, which is frequently a separate filesystem, and rename(2) across
+#     filesystems is not atomic -- mv silently degrades to copy-then-unlink.
+#   - rename installs a new inode, so mode and ownership have to be carried
+#     over explicitly; the previous in-place write got them for free.
+#
+# GRUB_FILE may be a symlink (and is one in some /etc layouts), so resolve it
+# first: the rename has to land on the real file rather than replace the link.
+# Returns non-zero without touching the target when staging or writing fails.
 _grub_write_options() {
-  local new="$1" tmp
-  tmp="$(mktemp)"
-  awk -v repl="GRUB_CMDLINE_LINUX_DEFAULT=\"$new\"" '
+  local new="$1" target dir tmp
+  target="$(readlink -f -- "$GRUB_FILE" 2>/dev/null || printf '%s\n' "$GRUB_FILE")"
+  dir="$(dirname -- "$target")"
+
+  tmp="$(mktemp -- "$dir/.grub.XXXXXX")" || {
+    warn "cannot stage a replacement for $target in $dir"
+    return 1
+  }
+  chmod --reference="$target" -- "$tmp" 2>/dev/null || true
+  chown --reference="$target" -- "$tmp" 2>/dev/null || true
+
+  if ! awk -v repl="GRUB_CMDLINE_LINUX_DEFAULT=\"$new\"" '
     /^[[:space:]]*GRUB_CMDLINE_LINUX_DEFAULT=/ {
       if (!seen) { print repl; seen = 1 }
       next
     }
     { print }
     END { if (!seen) print repl }
-  ' "$GRUB_FILE" > "$tmp"
-  # Write through the existing inode so mode and ownership survive.
-  cat -- "$tmp" > "$GRUB_FILE"
-  rm -f -- "$tmp"
+  ' "$target" > "$tmp"; then
+    rm -f -- "$tmp"
+    warn "failed to build the replacement for $target"
+    return 1
+  fi
+
+  mv -f -- "$tmp" "$target" || {
+    rm -f -- "$tmp"
+    warn "failed to install the new $target"
+    return 1
+  }
+
   if command -v update-grub >/dev/null 2>&1; then
     update-grub
   elif command -v grub-mkconfig >/dev/null 2>&1; then
@@ -381,7 +415,7 @@ cmdline_add() {
       if (( changed )); then
         opts="${opts#"${opts%%[![:space:]]*}"}"
         opts="${opts%"${opts##*[![:space:]]}"}"
-        _grub_write_options "$opts"
+        _grub_write_options "$opts" || rc=1
       fi
       ;;
     *)
@@ -433,7 +467,7 @@ cmdline_remove() {
       done
       if (( changed )); then
         new="${new%"${new##*[![:space:]]}"}"
-        _grub_write_options "$new"
+        _grub_write_options "$new" || rc=1
       fi
       ;;
     *)

--- a/lib/distro.sh
+++ b/lib/distro.sh
@@ -1,0 +1,479 @@
+# shellcheck shell=bash
+#
+# lib/distro.sh -- platform abstraction for patch.sh.
+#
+# Sourced by patch.sh before any module is loaded. Because `with_module` runs
+# each module.sh in a subshell that inherits patch.sh's functions, everything
+# defined here is callable from any module.sh without changing the module
+# contract (MODULE_NAME / MODULE_FILES / module_* hooks are untouched).
+#
+# Ground rule: the Arch branch of every function emits exactly the command the
+# modules ran before this file existed, in the same order. Behaviour on Arch
+# and its derivatives is unchanged; the other branches are additive.
+#
+# Provided:
+#   detection   distro_family
+#   packages    pkg_manager pkg_version pkg_installed pkg_available
+#               pkg_atleast pkg_install pkg_remove_hint
+#   kernel      kernel_list kernel_headers_present kernel_headers_install
+#               initramfs_regen
+#   boot params cmdline_backend cmdline_active cmdline_active_value
+#               cmdline_configured cmdline_add cmdline_remove
+#   services    svc_unit svc_exists svc_is_active svc_enable_now
+#               svc_disable_now
+#
+# Overridable for testing (never set in normal use):
+#   GRUB_FILE  KERNELSTUB_FILE  LIMINE_DROPIN_DIR  CMDLINE_BACKEND
+
+# ----------------------------------------------------------------- detection
+
+# distro_family -> arch | debian | unknown
+#
+# Reads ID *and* ID_LIKE. ID alone is not enough: Pop!_OS is `ID=pop
+# ID_LIKE="ubuntu debian"`, CachyOS/EndeavourOS/Manjaro are `ID_LIKE=arch`.
+distro_family() {
+  local id="" id_like="" token
+  if [[ -r /etc/os-release ]]; then
+    # shellcheck disable=SC1091
+    id="$( { . /etc/os-release; printf '%s' "${ID:-}"; } 2>/dev/null || true )"
+    # shellcheck disable=SC1091
+    id_like="$( { . /etc/os-release; printf '%s' "${ID_LIKE:-}"; } 2>/dev/null || true )"
+  fi
+  # Deliberately unquoted: ID_LIKE is a space-separated list.
+  # shellcheck disable=SC2086
+  for token in $id $id_like; do
+    case "$token" in
+      arch)          echo arch;   return 0 ;;
+      debian|ubuntu) echo debian; return 0 ;;
+    esac
+  done
+  # No usable os-release (container, minimal chroot): trust what is installed.
+  if command -v pacman >/dev/null 2>&1; then
+    echo arch
+  elif command -v dpkg-query >/dev/null 2>&1; then
+    echo debian
+  else
+    echo unknown
+  fi
+}
+
+# ------------------------------------------------------------------ packages
+
+# pkg_manager -> pacman | apt | none
+pkg_manager() {
+  local family
+  family="$(distro_family)"
+  if [[ $family == arch ]] && command -v pacman >/dev/null 2>&1; then
+    echo pacman
+  elif [[ $family == debian ]] && command -v dpkg-query >/dev/null 2>&1; then
+    echo apt
+  elif command -v pacman >/dev/null 2>&1; then
+    echo pacman
+  elif command -v dpkg-query >/dev/null 2>&1; then
+    echo apt
+  else
+    echo none
+  fi
+}
+
+# pkg_version <pkg> -- installed version, empty when not installed.
+pkg_version() {
+  local out=""
+  case "$(pkg_manager)" in
+    pacman)
+      out="$(pacman -Q "$1" 2>/dev/null | awk '{print $2}' || true)"
+      ;;
+    apt)
+      # dpkg-query -W also succeeds for removed-but-known packages, so filter
+      # on the status field rather than on the exit code.
+      out="$(dpkg-query -W -f='${db:Status-Status}\t${Version}' "$1" 2>/dev/null \
+             | awk -F'\t' '$1 == "installed" { print $2 }' || true)"
+      ;;
+  esac
+  printf '%s\n' "$out"
+}
+
+# pkg_installed <pkg>
+pkg_installed() {
+  [[ -n "$(pkg_version "$1")" ]]
+}
+
+# pkg_available <pkg> -- known to the configured repositories?
+pkg_available() {
+  local candidate
+  case "$(pkg_manager)" in
+    pacman)
+      pacman -Si "$1" >/dev/null 2>&1
+      ;;
+    apt)
+      # LC_ALL=C: apt-cache policy translates its field labels.
+      candidate="$(LC_ALL=C apt-cache policy "$1" 2>/dev/null \
+                   | awk '/^ *Candidate:/ { print $2; exit }' || true)"
+      [[ -n $candidate && $candidate != "(none)" ]]
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# pkg_atleast <pkg> <min-version> -- installed version >= min-version?
+#
+# Generalises the sort -V comparison audio-fix already used to gate its bundled
+# UCM files against alsa-ucm-conf 1.2.16.
+pkg_atleast() {
+  local have lowest
+  have="$(pkg_version "$1")"
+  have="${have#*:}"     # drop an epoch  (1:2.5.6 -> 2.5.6)
+  have="${have%%-*}"    # drop pkgrel / Debian revision
+  [[ -n $have ]] || return 1
+  lowest="$(printf '%s\n%s\n' "$2" "$have" | sort -V | sed -n '1p')"
+  [[ $lowest == "$2" ]]
+}
+
+# pkg_install <pkg>...
+pkg_install() {
+  (( $# > 0 )) || return 0
+  case "$(pkg_manager)" in
+    pacman)
+      pacman -S --needed --noconfirm "$@"
+      ;;
+    apt)
+      if DEBIAN_FRONTEND=noninteractive apt-get install -y "$@"; then
+        return 0
+      fi
+      log "refreshing the package index and retrying"
+      DEBIAN_FRONTEND=noninteractive apt-get update
+      DEBIAN_FRONTEND=noninteractive apt-get install -y "$@"
+      ;;
+    *)
+      warn "no supported package manager; install by hand: $*"
+      return 1
+      ;;
+  esac
+}
+
+# pkg_remove_hint <pkg>... -- the removal command to print for the user.
+pkg_remove_hint() {
+  case "$(pkg_manager)" in
+    pacman) printf 'sudo pacman -Rns %s\n' "$*" ;;
+    apt)    printf 'sudo apt-get purge %s\n' "$*" ;;
+    *)      printf 'remove by hand: %s\n'   "$*" ;;
+  esac
+}
+
+# ------------------------------------------------- kernel headers / initramfs
+
+# kernel_list -- installed kernel release names, one per line.
+kernel_list() {
+  local dir kver seen=""
+  for dir in /usr/lib/modules/*/ /lib/modules/*/; do
+    [[ -d $dir ]] || continue
+    kver="${dir%/}"; kver="${kver##*/}"
+    # /lib/modules and /usr/lib/modules are the same tree on merged-usr systems.
+    case " $seen " in *" $kver "*) continue ;; esac
+    seen="$seen $kver"
+    printf '%s\n' "$kver"
+  done
+}
+
+# kernel_headers_present [kernel-release]
+kernel_headers_present() {
+  local kver="${1:-$(uname -r)}"
+  [[ -e "/usr/lib/modules/$kver/build/Makefile" ]] ||
+    [[ -e "/lib/modules/$kver/build/Makefile" ]]
+}
+
+# kernel_headers_install [kernel-release]
+#
+# Arch keeps the source package name in /lib/modules/<kver>/pkgbase, so the
+# headers package is "<pkgbase>-headers" -- the same lookup audio-fix did
+# inline. Debian names them linux-headers-<kver> directly.
+kernel_headers_install() {
+  local kver="${1:-$(uname -r)}" package=""
+  kernel_headers_present "$kver" && return 0
+  case "$(pkg_manager)" in
+    pacman)
+      if [[ -r /lib/modules/$kver/pkgbase ]]; then
+        package="$(<"/lib/modules/$kver/pkgbase")-headers"
+      fi
+      ;;
+    apt)
+      package="linux-headers-$kver"
+      ;;
+  esac
+  if [[ -z $package ]]; then
+    warn "cannot map kernel $kver to a headers package"
+    return 1
+  fi
+  log "installing kernel headers for $kver: $package"
+  pkg_install "$package" || return 1
+  kernel_headers_present "$kver"
+}
+
+# initramfs_regen [reason]
+#
+# Arch order (limine-mkinitcpio, then mkinitcpio -P) is preserved, so this is a
+# drop-in for audio-fix's audio_refresh_initramfs. A system with no generator
+# at all is reported but not treated as an error, matching the previous
+# silent no-op.
+initramfs_regen() {
+  local reason="${1:-after the change}"
+  if command -v limine-mkinitcpio >/dev/null 2>&1; then
+    log "rebuilding Limine initramfs entries $reason"
+    limine-mkinitcpio
+  elif command -v mkinitcpio >/dev/null 2>&1; then
+    log "rebuilding initramfs images $reason"
+    mkinitcpio -P
+  elif command -v update-initramfs >/dev/null 2>&1; then
+    log "rebuilding initramfs images $reason"
+    update-initramfs -u -k all
+  elif command -v dracut >/dev/null 2>&1; then
+    log "rebuilding initramfs images $reason"
+    dracut --force --regenerate-all
+  else
+    warn "no initramfs generator found; initramfs was not rebuilt"
+  fi
+}
+
+# ---------------------------------------------------------- kernel cmdline
+
+GRUB_FILE="${GRUB_FILE:-/etc/default/grub}"
+KERNELSTUB_FILE="${KERNELSTUB_FILE:-/etc/kernelstub/configuration}"
+LIMINE_DROPIN_DIR="${LIMINE_DROPIN_DIR:-/etc/limine-entry-tool.d}"
+LIMINE_CMDLINE_DROPIN="$LIMINE_DROPIN_DIR/95-asus-expertbook-linux-cmdline.conf"
+
+# cmdline_backend -> limine | kernelstub | grub | none
+#
+# Limine is probed first so Arch/CachyOS keeps using the source of truth
+# display-fix already writes to. CMDLINE_BACKEND forces a backend (testing, or
+# a machine where the probe guesses wrong).
+cmdline_backend() {
+  if [[ -n ${CMDLINE_BACKEND:-} ]]; then
+    printf '%s\n' "$CMDLINE_BACKEND"
+  elif command -v limine-update >/dev/null 2>&1 ||
+       command -v limine-mkinitcpio >/dev/null 2>&1; then
+    echo limine
+  elif command -v kernelstub >/dev/null 2>&1; then
+    echo kernelstub
+  elif [[ -f $GRUB_FILE ]] &&
+       { command -v update-grub >/dev/null 2>&1 ||
+         command -v grub-mkconfig >/dev/null 2>&1; }; then
+    echo grub
+  else
+    echo none
+  fi
+}
+
+# cmdline_active <param> -- is the exact token on the running kernel cmdline?
+cmdline_active() {
+  local want="$1" token
+  while IFS= read -r token; do
+    [[ $token == "$want" ]] && return 0
+  done < <(tr ' ' '\n' < /proc/cmdline 2>/dev/null || true)
+  return 1
+}
+
+# cmdline_active_value <key> -- value of key=... on the running cmdline.
+cmdline_active_value() {
+  local key="$1" token value=""
+  while IFS= read -r token; do
+    [[ $token == "$key="* ]] && value="${token#*=}"
+  done < <(tr ' ' '\n' < /proc/cmdline 2>/dev/null || true)
+  printf '%s\n' "$value"
+}
+
+_grub_options() {
+  [[ -f $GRUB_FILE ]] || return 0
+  sed -n 's/^[[:space:]]*GRUB_CMDLINE_LINUX_DEFAULT="\(.*\)"[[:space:]]*$/\1/p' \
+    "$GRUB_FILE" | tail -n1
+}
+
+_grub_write_options() {
+  local new="$1" tmp
+  tmp="$(mktemp)"
+  awk -v repl="GRUB_CMDLINE_LINUX_DEFAULT=\"$new\"" '
+    /^[[:space:]]*GRUB_CMDLINE_LINUX_DEFAULT=/ {
+      if (!seen) { print repl; seen = 1 }
+      next
+    }
+    { print }
+    END { if (!seen) print repl }
+  ' "$GRUB_FILE" > "$tmp"
+  # Write through the existing inode so mode and ownership survive.
+  cat -- "$tmp" > "$GRUB_FILE"
+  rm -f -- "$tmp"
+  if command -v update-grub >/dev/null 2>&1; then
+    update-grub
+  elif command -v grub-mkconfig >/dev/null 2>&1; then
+    grub-mkconfig -o /boot/grub/grub.cfg
+  fi
+}
+
+_limine_regen() {
+  if command -v limine-update >/dev/null 2>&1; then
+    limine-update
+  elif command -v limine-mkinitcpio >/dev/null 2>&1; then
+    limine-mkinitcpio
+  else
+    warn "Limine tooling not found; kernel parameters were not activated"
+    return 1
+  fi
+}
+
+# cmdline_configured <param> -- staged in the bootloader config (may still
+# need a reboot to become active)?
+cmdline_configured() {
+  local param="$1" token
+  case "$(cmdline_backend)" in
+    limine)
+      [[ -f $LIMINE_CMDLINE_DROPIN ]] &&
+        grep -qF -- "$param" "$LIMINE_CMDLINE_DROPIN"
+      ;;
+    kernelstub)
+      [[ -f $KERNELSTUB_FILE ]] &&
+        grep -qF -- "\"$param\"" "$KERNELSTUB_FILE"
+      ;;
+    grub)
+      for token in $(_grub_options); do
+        [[ $token == "$param" ]] && return 0
+      done
+      return 1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# cmdline_add <param>... -- idempotent. Returns non-zero when the parameters
+# were staged but the bootloader could not be regenerated.
+cmdline_add() {
+  (( $# > 0 )) || return 0
+  local param opts changed=0 rc=0
+  case "$(cmdline_backend)" in
+    limine)
+      install -d -m 0755 "$LIMINE_DROPIN_DIR"
+      for param in "$@"; do
+        cmdline_configured "$param" && continue
+        printf 'KERNEL_CMDLINE[default]+=" %s"\n' "$param" \
+          >> "$LIMINE_CMDLINE_DROPIN"
+        changed=1
+      done
+      if (( changed )); then
+        _limine_regen || rc=1
+      fi
+      ;;
+    kernelstub)
+      for param in "$@"; do
+        cmdline_configured "$param" && continue
+        kernelstub -a "$param" >/dev/null
+        changed=1
+      done
+      ;;
+    grub)
+      opts=" $(_grub_options) "
+      for param in "$@"; do
+        [[ $opts == *" $param "* ]] && continue
+        opts="$opts$param "
+        changed=1
+      done
+      if (( changed )); then
+        opts="${opts#"${opts%%[![:space:]]*}"}"
+        opts="${opts%"${opts##*[![:space:]]}"}"
+        _grub_write_options "$opts"
+      fi
+      ;;
+    *)
+      warn "no supported bootloader backend; add by hand to the kernel cmdline: $*"
+      return 1
+      ;;
+  esac
+  return "$rc"
+}
+
+# cmdline_remove <param>... -- idempotent. Returns non-zero when the change
+# was staged but the bootloader could not be regenerated.
+cmdline_remove() {
+  (( $# > 0 )) || return 0
+  local param opts token new changed=0 rc=0 tmp
+  case "$(cmdline_backend)" in
+    limine)
+      [[ -f $LIMINE_CMDLINE_DROPIN ]] || return 0
+      for param in "$@"; do
+        cmdline_configured "$param" || continue
+        tmp="$(mktemp)"
+        grep -vF -- "$param" "$LIMINE_CMDLINE_DROPIN" > "$tmp" || true
+        cat -- "$tmp" > "$LIMINE_CMDLINE_DROPIN"
+        rm -f -- "$tmp"
+        changed=1
+      done
+      [[ -s $LIMINE_CMDLINE_DROPIN ]] || rm -f -- "$LIMINE_CMDLINE_DROPIN"
+      if (( changed )); then
+        _limine_regen || rc=1
+      fi
+      ;;
+    kernelstub)
+      for param in "$@"; do
+        cmdline_configured "$param" || continue
+        kernelstub -d "$param" >/dev/null
+        changed=1
+      done
+      ;;
+    grub)
+      new=""
+      for token in $(_grub_options); do
+        for param in "$@"; do
+          if [[ $token == "$param" ]]; then
+            changed=1
+            continue 2
+          fi
+        done
+        new="$new$token "
+      done
+      if (( changed )); then
+        new="${new%"${new##*[![:space:]]}"}"
+        _grub_write_options "$new"
+      fi
+      ;;
+    *)
+      warn "no supported bootloader backend; remove by hand from the kernel cmdline: $*"
+      return 1
+      ;;
+  esac
+  return "$rc"
+}
+
+# ------------------------------------------------------------------ services
+
+# svc_unit <candidate>... -- first unit file that exists. Falls back to the
+# first candidate so status output always has a name to print.
+#
+# Not paranoia: intel-lpmd ships as intel_lpmd.service on Arch, and the unit
+# name is a packaging decision each distribution makes independently.
+svc_unit() {
+  local candidate
+  for candidate in "$@"; do
+    if [[ -n "$(systemctl list-unit-files --no-legend "$candidate" 2>/dev/null)" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  printf '%s\n' "${1:-}"
+}
+
+svc_exists() {
+  [[ -n "$(systemctl list-unit-files --no-legend "$1" 2>/dev/null)" ]]
+}
+
+svc_is_active() {
+  systemctl is-active --quiet "$1"
+}
+
+svc_enable_now() {
+  systemctl enable --now "$1"
+}
+
+svc_disable_now() {
+  systemctl disable --now "$1"
+}

--- a/patch.sh
+++ b/patch.sh
@@ -37,6 +37,17 @@ ok()   { printf '%sOK%s   %s\n' "$c_ok" "$c_off" "$*"; }
 warn() { printf '%sWARN%s %s\n' "$c_warn" "$c_off" "$*"; }
 die()  { printf '%sERR%s  %s\n' "$c_err" "$c_off" "$*" >&2; exit 1; }
 
+# Platform abstraction: package manager, kernel headers, initramfs, bootloader
+# cmdline, services. Sourced before any module is loaded so every module.sh can
+# call these helpers via the `with_module` subshell. lib/ contains no module.sh,
+# so discover_modules never mistakes it for a module.
+if [[ -f "$ROOT_DIR/lib/distro.sh" ]]; then
+  # shellcheck source=lib/distro.sh
+  source "$ROOT_DIR/lib/distro.sh"
+else
+  die "missing $ROOT_DIR/lib/distro.sh"
+fi
+
 usage() {
   sed -n '3,21p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }

--- a/scripts/check-hardware.sh
+++ b/scripts/check-hardware.sh
@@ -11,6 +11,55 @@ ok()    { printf '  %sOK%s   %s\n' "$c_ok" "$c_off" "$*"; }
 warn()  { printf '  %sWARN%s %s\n' "$c_warn" "$c_off" "$*"; }
 fail()  { printf '  %sFAIL%s %s\n' "$c_err" "$c_off" "$*"; }
 note()  { printf '  %s%s%s\n' "$c_dim" "$*" "$c_off"; }
+log()   { note "$*"; }
+die()   { fail "$*"; exit 1; }
+
+# Report the platform exactly as the patcher resolves it. Run from a clone this
+# uses lib/distro.sh itself; the README also documents this script as a
+# `curl | bash` one-liner, where that file is not on disk, so the three probes
+# it needs have a self-contained fallback below.
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+# shellcheck source=../lib/distro.sh
+[[ -f "$SCRIPT_DIR/../lib/distro.sh" ]] && source "$SCRIPT_DIR/../lib/distro.sh"
+
+if ! declare -F distro_family >/dev/null; then
+  distro_family() {
+    local id="" id_like="" token
+    if [[ -r /etc/os-release ]]; then
+      # shellcheck disable=SC1091
+      id="$( { . /etc/os-release; printf '%s' "${ID:-}"; } 2>/dev/null || true )"
+      # shellcheck disable=SC1091
+      id_like="$( { . /etc/os-release; printf '%s' "${ID_LIKE:-}"; } 2>/dev/null || true )"
+    fi
+    # shellcheck disable=SC2086
+    for token in $id $id_like; do
+      case "$token" in
+        arch)          echo arch;   return 0 ;;
+        debian|ubuntu) echo debian; return 0 ;;
+      esac
+    done
+    if command -v pacman >/dev/null 2>&1; then echo arch
+    elif command -v dpkg-query >/dev/null 2>&1; then echo debian
+    else echo unknown
+    fi
+  }
+  pkg_manager() {
+    if command -v pacman >/dev/null 2>&1; then echo pacman
+    elif command -v dpkg-query >/dev/null 2>&1; then echo apt
+    else echo none
+    fi
+  }
+  cmdline_backend() {
+    if command -v limine-update >/dev/null 2>&1 ||
+       command -v limine-mkinitcpio >/dev/null 2>&1; then echo limine
+    elif command -v kernelstub >/dev/null 2>&1; then echo kernelstub
+    elif [[ -f /etc/default/grub ]] &&
+         { command -v update-grub >/dev/null 2>&1 ||
+           command -v grub-mkconfig >/dev/null 2>&1; }; then echo grub
+    else echo none
+    fi
+  }
+fi
 
 printf '%sasus-expertbook-linux — hardware compatibility probe%s\n\n' "$c_bold" "$c_off"
 
@@ -186,13 +235,23 @@ echo
 
 # 10) Distro
 printf '%sDistro%s\n' "$c_bold" "$c_off"
-if [[ -f /etc/arch-release ]]; then
-  ok "Arch (or derivative) — patcher's pacman + paths assumed correct"
-elif command -v pacman >/dev/null 2>&1; then
-  ok "$(awk -F= '/^PRETTY_NAME=/{gsub(/"/,""); print $2}' /etc/os-release 2>/dev/null) — pacman present"
-else
-  warn "non-pacman distro — modules' files still apply, but intel-perf-fix's package install will need adapting"
-fi
+pretty="$(awk -F= '/^PRETTY_NAME=/{gsub(/"/,""); print $2}' /etc/os-release 2>/dev/null)"
+case "$(distro_family)" in
+  arch)
+    ok "${pretty:-Arch (or derivative)} — pacman; every module is supported here"
+    ;;
+  debian)
+    ok "${pretty:-Debian (or derivative)} — apt/dpkg"
+    note "supported so far: intel-perf-fix, plus every module whose payload is"
+    note "plain config files (touchpad-fix, wifi-fix). The remaining modules still"
+    note "assume Arch — see issue #4 for the cross-distro port status."
+    ;;
+  *)
+    warn "${pretty:-unknown distribution} — no supported package manager detected"
+    note "file-only modules still apply; anything that installs packages will not"
+    ;;
+esac
+note "package manager: $(pkg_manager)    boot parameters: $(cmdline_backend)"
 echo
 
 # Summary
@@ -202,6 +261,11 @@ all_pass=1
 
 if (( all_pass == 1 )); then
   printf '%sResult: install-all is appropriate for this hardware.%s\n' "$c_ok" "$c_off"
+  if [[ "$(distro_family)" != arch ]]; then
+    printf '%sModules that install packages from the AUR (webcam-ai-fix,\n' "$c_dim"
+    printf 'keyboard-backlight-fix) are still Arch-only: install-all runs them but\n'
+    printf 'they will not install anything here.%s\n' "$c_off"
+  fi
   printf '\n  git clone https://github.com/burakgon/asus-expertbook-linux.git\n'
   printf '  cd asus-expertbook-linux\n'
   printf '  ./patch.sh install-all\n'

--- a/scripts/check-hardware.sh
+++ b/scripts/check-hardware.sh
@@ -242,9 +242,9 @@ case "$(distro_family)" in
     ;;
   debian)
     ok "${pretty:-Debian (or derivative)} — apt/dpkg"
-    note "supported so far: intel-perf-fix, plus every module whose payload is"
-    note "plain config files (touchpad-fix, wifi-fix). The remaining modules still"
-    note "assume Arch — see issue #4 for the cross-distro port status."
+    note "supported so far: intel-perf-fix, plus every module that only ships"
+    note "files and units (touchpad-fix, wifi-fix, keyboard-backlight-auto)."
+    note "The rest still assume Arch — see issue #4 for the port status."
     ;;
   *)
     warn "${pretty:-unknown distribution} — no supported package manager detected"

--- a/scripts/check-hardware.sh
+++ b/scripts/check-hardware.sh
@@ -260,15 +260,28 @@ all_pass=1
 [[ "$cpu" == *"Core(TM) Ultra"* ]] || all_pass=0
 
 if (( all_pass == 1 )); then
-  printf '%sResult: install-all is appropriate for this hardware.%s\n' "$c_ok" "$c_off"
-  if [[ "$(distro_family)" != arch ]]; then
-    printf '%sModules that install packages from the AUR (webcam-ai-fix,\n' "$c_dim"
-    printf 'keyboard-backlight-fix) are still Arch-only: install-all runs them but\n'
-    printf 'they will not install anything here.%s\n' "$c_off"
+  # install-all is not harmless outside Arch. webcam-ai-fix declares no
+  # module_install, so mod_install_files runs whatever the distro: it drops
+  # /etc/modules-load.d/v4l2loopback.conf for a module Debian does not package,
+  # leaving systemd-modules-load to fail at every boot, and its post-install
+  # adds the invoking user to the render group. So name the ported modules here
+  # rather than claim the Arch-only ones do nothing.
+  if [[ "$(distro_family)" == arch ]]; then
+    install_cmd='./patch.sh install-all'
+    printf '%sResult: install-all is appropriate for this hardware.%s\n' "$c_ok" "$c_off"
+  else
+    install_cmd='./patch.sh install touchpad-fix wifi-fix keyboard-backlight-auto intel-perf-fix'
+    printf '%sResult: the hardware matches. Install the ported modules, not install-all.%s\n' \
+      "$c_ok" "$c_off"
+    printf '%sinstall-all would also run the Arch-only modules. webcam-ai-fix still\n' "$c_dim"
+    printf 'writes its modules-load.d and modprobe.d files and adds you to the render\n'
+    printf 'group, even though v4l2loopback-dkms and obs-backgroundremoval cannot be\n'
+    printf 'installed here. keyboard-backlight-fix is the harmless one: it skips itself\n'
+    printf 'on every distro, superseded by keyboard-backlight-auto.%s\n' "$c_off"
   fi
   printf '\n  git clone https://github.com/burakgon/asus-expertbook-linux.git\n'
   printf '  cd asus-expertbook-linux\n'
-  printf '  ./patch.sh install-all\n'
+  printf '  %s\n' "$install_cmd"
   printf '  sudo reboot\n\n'
 else
   printf '%sResult: not a perfect match.%s Some modules may still help — pick à la carte\n' "$c_warn" "$c_off"


### PR DESCRIPTION
Follows up on #4 — the first step: shims plus one module, Arch behaviour
unchanged.

`lib/distro.sh` covers the four boundaries you listed: package install and
version queries, kernel-header discovery and initramfs regeneration, the
kernel-cmdline backend (Limine / kernelstub / GRUB), and service enablement.
It lives in `lib/`, so `discover_modules()` never picks it up as a module;
`patch.sh` sources it before any module loads, and since `with_module()`
already runs manifests in a subshell that inherits the script's functions,
hooks can call the helpers with no change to the module contract.

Every Arch branch emits the command it emitted before, in the same order. Two
exceptions, both intentional and both in `intel-perf-fix`:
`module_status_extra` now skips a unit that does not exist — `systemctl
is-active` answers `inactive` for one that was never installed, so the existing
silent case could never match — and `intel_lpmd.service` is only enabled when
the package actually installed.

`intel-perf-fix` (v1.2.0) is the ported module. `audio-fix` and `display-fix`
move onto the helpers only where the substitution is exact, so the shim has
real callers; that also fixes `ucm_hifi_is_upstream`, which opened with
`command -v pacman || return 1` and so overwrote `/usr/share/alsa/ucm2/` on any
non-pacman system regardless of the installed version.

Tested on Pop!_OS 24.04: install, status, uninstall, reinstall. The unit is
`intel_lpmd.service` there too, and the removal hint reads `apt-get purge`.

Worth knowing: on Ubuntu 24.04 `intel-lpmd` installs, enables, then exits four
milliseconds later — the packaged 0.0.3 (February 2024) predates this CPU and
takes its "Unsupported CPU type" path without logging. Debian families get the
thermald half only for now; the module says so at install and in `status`, and
leaves the unit enabled so a later upgrade starts working on its own.

Deferred, happy to take either next: `display-fix`'s cmdline write path onto the
new backend — implemented and tested, but I'd rather not rewrite the module you
just shipped without being able to exercise the Limine path — and `audio-fix`,
where `NoExtract` needs a `dpkg-divert` equivalent.

Leaving #4 open as the tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbfbrSQgdjHSbb3oRF9bgt
