### PR TITLE
fix(audio): DKMS overlay never builds on a GCC kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ typing single letters. Numbered table, color-coded state, cached.
 
   #   Module                    Version  Installed State          Description
   ------------------------------------------------------------------------------------
-  1   audio-fix                 3.1.0    3.1.0     up to date     Adaptive ghost-RT722 fix + HiFi audio
+  1   audio-fix                 3.1.1    3.1.1     up to date     Adaptive ghost-RT722 fix + HiFi audio
   2   camera-firmware           3009     3009      up to date     Verified camera UEFI capsule
   3   display-fix               1.3.0    1.3.0     up to date     Linux 7.2 display defaults + DPCD brightness
   4   intel-perf-fix            1.1.0    1.1.0     up to date     thermald + intel-lpmd

--- a/audio-fix/README.md
+++ b/audio-fix/README.md
@@ -132,6 +132,26 @@ The exact patch is retained in
 for stable/distro backports. It landed after Linux 7.2 and is absent from 7.2.1;
 the installer detects the actual module marker instead of assuming a version.
 
+### DKMS build fails with `clang: error: unknown argument`
+
+The overlay must be compiled with the same toolchain as the target kernel. Arch's
+`linux` is GCC-built; CachyOS kernels are Clang/ThinLTO. Forcing the wrong one
+fails immediately, because the kernel exports compiler-specific CFLAGS:
+
+```
+clang: error: unknown argument: '-mindirect-branch=thunk-extern'
+clang: error: unsupported option '-mrecord-mcount'
+```
+
+`dkms.conf` picks the toolchain per kernel from that kernel's own
+`CONFIG_CC_IS_CLANG`, adding `LLVM=1` only for a Clang-built kernel. If a stale
+build is cached, reinstall to re-register the source:
+
+```sh
+./patch.sh install audio-fix
+cat /var/lib/dkms/asus-expertbook-sof-sdw/3.0.0/build/make.log   # on failure
+```
+
 ## Uninstall
 
 ```sh

--- a/audio-fix/dkms/asus-expertbook-sof-sdw-3.0.0/dkms.conf
+++ b/audio-fix/dkms/asus-expertbook-sof-sdw-3.0.0/dkms.conf
@@ -5,6 +5,18 @@ AUTOINSTALL="yes"
 BUILT_MODULE_NAME[0]="snd-soc-sof-sdw"
 DEST_MODULE_LOCATION[0]="/updates"
 
-# CachyOS kernels use Clang/ThinLTO. LLVM=1 is also safe for Arch kernels and
-# avoids silently producing an incompatible object for CachyOS.
-MAKE[0]="make -C /lib/modules/${kernelver}/build M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build modules LLVM=1"
+# LLVM=1 only for a clang-built kernel: a GCC kernel's CFLAGS break clang.
+_asus_ksrc="${kernel_source_dir:-/lib/modules/${kernelver}/build}"
+_asus_kconfig="${kernel_config:-}"
+if [[ -z $_asus_kconfig ]]; then
+  if [[ -e $_asus_ksrc/include/config/auto.conf ]]; then
+    _asus_kconfig="$_asus_ksrc/include/config/auto.conf"
+  else
+    _asus_kconfig="$_asus_ksrc/.config"
+  fi
+fi
+
+_asus_llvm=""
+grep -qs '^CONFIG_CC_IS_CLANG=y' "$_asus_kconfig" && _asus_llvm=" LLVM=1"
+
+MAKE[0]="make -C ${_asus_ksrc} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build modules${_asus_llvm}"

--- a/audio-fix/module.sh
+++ b/audio-fix/module.sh
@@ -50,7 +50,7 @@
 
 MODULE_NAME="audio-fix"
 MODULE_DESC="B9406CAA audio: adaptive ghost-RT722 fix + HiFi UCM + cs35l56 firmware"
-MODULE_VERSION="3.1.0"
+MODULE_VERSION="3.1.1"
 
 AUDIO_DKMS_NAME="asus-expertbook-sof-sdw"
 AUDIO_DKMS_VERSION="3.0.0"
@@ -169,10 +169,34 @@ audio_remove_legacy_dkms() {
   done
 }
 
+# Echoes gcc or clang. Defaults to gcc until the headers are installed.
+audio_kernel_toolchain() {
+  local kernel="${1:-$(uname -r)}" config
+  for config in "/usr/lib/modules/$kernel/build/include/config/auto.conf" \
+                "/usr/lib/modules/$kernel/build/.config"; do
+    [[ -r $config ]] || continue
+    if grep -qs '^CONFIG_CC_IS_CLANG=y' "$config"; then
+      printf 'clang\n'
+    else
+      printf 'gcc\n'
+    fi
+    return
+  done
+  printf 'gcc\n'
+}
+
 audio_require_build_tools() {
-  local missing=() package
-  for package in dkms make clang; do
-    command -v "$package" >/dev/null 2>&1 || missing+=("$package")
+  local -a kernels=("$@") wanted=(dkms make) missing=()
+  local package kernel
+
+  (( ${#kernels[@]} > 0 )) || kernels=("$(uname -r)")
+  for kernel in "${kernels[@]}"; do
+    wanted+=("$(audio_kernel_toolchain "$kernel")")
+  done
+
+  for package in "${wanted[@]}"; do
+    command -v "$package" >/dev/null 2>&1 && continue
+    [[ " ${missing[*]} " == *" $package "* ]] || missing+=("$package")
   done
 
   if (( ${#missing[@]} > 0 )); then
@@ -245,7 +269,7 @@ audio_install_dkms() {
   (( ${#build_kernels[@]} > 0 )) || \
     die "[audio-fix] kernels need the ghost-RT722 overlay, but no matching headers were found"
 
-  audio_require_build_tools
+  audio_require_build_tools "${build_kernels[@]}"
   install -d -m 0755 "$AUDIO_DKMS_TARGET"
   cp -a -- "$AUDIO_DKMS_SOURCE/." "$AUDIO_DKMS_TARGET/"
   dkms add -m "$AUDIO_DKMS_NAME" -v "$AUDIO_DKMS_VERSION"

--- a/audio-fix/module.sh
+++ b/audio-fix/module.sh
@@ -92,24 +92,29 @@ ucm_hifi_is_upstream() {
   [[ $lowest == 1.2.16 ]]
 }
 
+audio_module_strings() {
+  case "$1" in
+    *.zst) zstdcat -- "$1" 2>/dev/null ;;
+    *.xz)  xzcat -- "$1" 2>/dev/null ;;
+    *.gz)  gzip -cd -- "$1" 2>/dev/null ;;
+    *)     cat -- "$1" 2>/dev/null ;;
+  esac | strings
+}
+
 # audio_kernel_has_upstream_ghost_quirk [kernel-release]
 #
 # Do not rely on a kernel version: distributions may backport the fix. The
-# accepted SoundWire DMI entry embeds the exact board name in soundwire_bus, so
-# inspecting that module is both backport-safe and independent of the running
-# kernel. Commit: 90af3209742db61a7f9d7d054a16165818cfc6d8.
+# accepted SoundWire DMI entry embeds the exact board name in soundwire_intel,
+# so inspecting that module is both backport-safe and independent of the
+# running kernel. Commit: 90af3209742db61a7f9d7d054a16165818cfc6d8.
 audio_kernel_has_upstream_ghost_quirk() {
-  local kernel="${1:-$(uname -r)}" module marker=""
-  module="$(modinfo -k "$kernel" -n soundwire_bus 2>/dev/null || true)"
-  [[ -f $module ]] || return 1
-
-  case "$module" in
-    *.zst) marker="$(zstdcat -- "$module" 2>/dev/null | strings | grep -F 'B9406CAA' || true)" ;;
-    *.xz)  marker="$(xzcat -- "$module" 2>/dev/null | strings | grep -F 'B9406CAA' || true)" ;;
-    *.gz)  marker="$(gzip -cd -- "$module" 2>/dev/null | strings | grep -F 'B9406CAA' || true)" ;;
-    *)     marker="$(strings -- "$module" 2>/dev/null | grep -F 'B9406CAA' || true)" ;;
-  esac
-  [[ -n $marker ]]
+  local kernel="${1:-$(uname -r)}" name module
+  for name in soundwire_intel soundwire_bus; do
+    module="$(modinfo -k "$kernel" -n "$name" 2>/dev/null || true)"
+    [[ -f $module ]] || continue
+    audio_module_strings "$module" | grep -qF 'B9406CAA' && return 0
+  done
+  return 1
 }
 
 audio_dkms_installed_for_kernel() {

--- a/upstream-patches/README.md
+++ b/upstream-patches/README.md
@@ -24,7 +24,7 @@ Status checked against `torvalds/linux` and the released Linux 7.2.1 sources on
 The file here is the exact upstream commit patch, retained for distro/stable
 backports. It landed after Linux 7.2, and is absent from 7.2.1, so released
 kernels still need `audio-fix`'s DKMS overlay unless their distributor
-backported the commit. `audio-fix` 3.1 checks the installed `soundwire_bus`
+backported the commit. `audio-fix` 3.1 checks the installed `soundwire_intel`
 module for the B9406CAA marker per kernel: it builds DKMS only for kernels that
 lack the upstream quirk and removes the overlay once all installed kernels have
 it.


### PR DESCRIPTION
The DKMS overlay doesn't build on stock Arch. `dkms.conf` passes `LLVM=1`, but
Arch's `linux` is GCC-built, so clang rejects the kernel's own CFLAGS:

```
clang: error: unknown argument: '-mindirect-branch=thunk-extern'
clang: error: unknown argument: '-mpreferred-stack-boundary=3'
clang: error: unsupported option '-mrecord-mcount'
```

`dkms status` stops at `added` instead of `installed`, so nothing filters the
ghost RT722 and `/proc/asound/cards` stays empty. Annoying to track down,
because the module looks like it's there.

Fixed by reading `CONFIG_CC_IS_CLANG` from the target kernel and passing
`LLVM=1` only when that kernel is actually clang-built, so CachyOS is
unaffected. `audio_require_build_tools` always installed clang for the same
reason - now it installs whatever the build kernels need.

Second commit is a separate bug I ran into while checking the first one:
`audio_kernel_has_upstream_ghost_quirk` greps `soundwire_bus` for the B9406CAA
marker, but 90af3209742d patches `dmi-quirks.c`, which links into
`soundwire-intel`. `soundwire-bus.ko` has no quirk table in it at all, so that
check can never come back true. Doesn't matter yet, but once a kernel ships
the quirk it'll keep rebuilding the overlay instead of dropping it.

Builds clean against 7.2.4-arch1-2, vermagic matches the stock module.
